### PR TITLE
fix: ensure /ask2 never returns empty answer

### DIFF
--- a/app/retrieval/app.py
+++ b/app/retrieval/app.py
@@ -1,12 +1,17 @@
 from fastapi import FastAPI, Query
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 
 app = FastAPI()
 
 class Answer(BaseModel):
     answer: str
-    sources: list[str] = []
-    meta: dict = {}
+    sources: list[str] = Field(default_factory=list)
+    meta: dict = Field(default_factory=dict)
+
+
+FALLBACK_MESSAGE = (
+    "I couldn’t find a direct answer in the indexed docs. Here are the most relevant sources."
+)
 
 @app.get("/ask2", response_model=Answer)
 def ask2(q: str = Query(""), k: int = Query(4)):
@@ -14,4 +19,15 @@ def ask2(q: str = Query(""), k: int = Query(4)):
     if not q.strip():
         return Answer(answer="Ask me something about ESG/AI.", sources=[], meta={"k": k, "note": "empty query"})
     # Replace with your real retrieval/generation logic.
-    return Answer(answer=f"Echo: {q}", sources=[], meta={"k": k, "note": "stub"})
+    computed_answer = f"Echo: {q}"
+    sources: list[str] = []  # Populate with real source titles/urls when available.
+
+    if not computed_answer.strip():
+        limited_sources = sources[:3]
+        return Answer(
+            answer=FALLBACK_MESSAGE,
+            sources=limited_sources,
+            meta={"k": k, "note": "fallback", "original_answer": computed_answer},
+        )
+
+    return Answer(answer=computed_answer.strip(), sources=sources, meta={"k": k, "note": "stub"})

--- a/tests/test_ask2_contract.py
+++ b/tests/test_ask2_contract.py
@@ -1,0 +1,29 @@
+from importlib import util
+from pathlib import Path
+
+from fastapi.testclient import TestClient
+
+_module_path = Path(__file__).resolve().parents[1] / "app" / "retrieval" / "app.py"
+_spec = util.spec_from_file_location("retrieval_app", _module_path)
+assert _spec and _spec.loader
+_module = util.module_from_spec(_spec)
+_spec.loader.exec_module(_module)
+app = _module.app
+
+
+client = TestClient(app)
+
+
+def test_ask2_contract_keys():
+    response = client.get("/ask2", params={"q": "contract check"})
+    assert response.status_code == 200
+    payload = response.json()
+    for key in ("answer", "sources", "meta"):
+        assert key in payload
+
+
+def test_ask2_non_empty_answer():
+    response = client.get("/ask2", params={"q": "test"})
+    payload = response.json()
+    assert len(payload["answer"]) > 0
+    assert payload["answer"].strip()


### PR DESCRIPTION
## Summary
- Ensure `/ask2` never returns an empty `answer`.
- Trim generated text; when blank, return a friendly fallback and include up to 3 sources.
- Keep response shape exactly: {answer, sources, meta}.

## Tests
- `pytest -q` → 2 passed.

## Notes
- APEX contract unchanged (same URL/params/JSON keys).
