### PR TITLE
Add metrics endpoint to facade

### DIFF
--- a/.ask_facade/wsgi_ask_facade.py
+++ b/.ask_facade/wsgi_ask_facade.py
@@ -1,10 +1,12 @@
 from importlib import import_module
 import json, urllib.request, urllib.error, urllib.parse
+import time
 from flask import request, jsonify
 
 # import existing app
 app_mod = import_module("app")
 base_app = getattr(app_mod, "app", None)
+_MODULE_START_TS = time.time()
 
 def _shape(j):
     if not isinstance(j, dict):
@@ -125,6 +127,13 @@ if app:
     @app.route("/healthz", endpoint="healthz_facade")
     def _healthz_facade():
         return jsonify({"ok": True})
+
+    @app.route("/metrics", endpoint="metrics_facade")
+    def _metrics_facade():
+        uptime = time.time() - _MODULE_START_TS
+        if uptime <= 0:
+            uptime = 1e-6
+        return jsonify({"uptime": float(uptime)})
 
 # --- SustainaCore hotfix: ensure /ask2 never returns an empty "answer" ---
 from flask import request

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -37,6 +37,10 @@ jobs:
         run: |
           curl --fail --retry 12 --retry-delay 5 "http://${VM_HOST}:8080/healthz"
 
+      - name: Verify metrics
+        run: |
+          curl --fail --retry 12 --retry-delay 5 "http://${VM_HOST}:8080/metrics"
+
       - name: Service logs (on failure)
         if: failure()
         run: |

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -1,0 +1,32 @@
+import importlib.util
+import pathlib
+import sys
+
+ROOT = pathlib.Path(__file__).resolve().parents[1]
+
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+app_spec = importlib.util.spec_from_file_location("app", str(ROOT / "app.py"))
+app_module = importlib.util.module_from_spec(app_spec)
+app_spec.loader.exec_module(app_module)
+sys.modules.setdefault("app", app_module)
+
+facade_path = ROOT / ".ask_facade" / "wsgi_ask_facade.py"
+facade_spec = importlib.util.spec_from_file_location("ask_facade_wsgi", str(facade_path))
+facade_module = importlib.util.module_from_spec(facade_spec)
+facade_spec.loader.exec_module(facade_module)
+
+app = getattr(facade_module, "base_app", None)
+
+
+def test_metrics_positive_uptime():
+    assert app is not None, "Facade Flask app should be available"
+    with app.test_client() as client:
+        response = client.get("/metrics")
+        assert response.status_code == 200
+        payload = response.get_json()
+        assert isinstance(payload, dict)
+        uptime = payload.get("uptime")
+        assert isinstance(uptime, (int, float))
+        assert uptime > 0.0


### PR DESCRIPTION
## Summary
- expose a `/metrics` endpoint from the Flask facade that returns process uptime
- add a unit test covering the new metrics endpoint
- extend the deploy workflow to curl the metrics endpoint after the health check

## Testing
- python -m pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68d31e4e06d083289fdd45c9d5083fc3