### PR TITLE
Tighten Gemini answer sanitization and debug stripping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,16 @@
+# Changelog
+
+## 2025-09-10 – Gemini-first orchestration
+
+* Added Gemini CLI planning + composition as the only generation path.
+* Implemented Oracle 23ai retriever with filter-first vector search, aggressive
+  deduplication, and clean citation payloads.
+* Introduced per-request telemetry, daily Top-10 Miss reports, and IP rate
+  limiting.
+* Updated `/ask2` output schema to `answer + sources` with developer diagnostics
+  in `meta.debug` only.
+* Documented configuration, feature flags, and runbook in the new README.
+
+**Rollback:** set `GEMINI_FIRST_ENABLED=0` and reload the service to return to
+the previous behaviour without redeploying code.
+

--- a/README.md
+++ b/README.md
@@ -1,0 +1,107 @@
+# SustainaCore Gateway
+
+This repository exposes the `/ask2` entry-point that APEX uses to power the
+SustainaCore assistant. The service now runs a **Gemini-first retrieval and
+generation orchestration** while keeping Oracle Autonomous Database + 23ai
+vector search as the single system of record.
+
+## Gemini-First Orchestration
+
+### Request Flow
+
+1. **Intent classification** – Every query is sent to Gemini via the CLI to
+   decide between `SMALL_TALK` and `INFO_REQUEST`.
+2. **Small talk** – Gemini produces a 1–2 sentence reply. No retrieval happens
+   and no citations are returned.
+3. **Grounded Q&A** – Gemini returns a retrieval plan (filters + 3–5 query
+   variants). The local Oracle retriever executes the plan, deduplicates and
+   diversifies the top results (≤2 chunks per source, ≤1 per URL, keep the later
+   duplicates). Gemini then composes the final answer with inline citations and
+   a cleaned `Sources` list.
+
+### Oracle Retriever Contract
+
+* **Inputs** – `filters` (strict metadata), `query_variants` (3–5 strings) and
+  `k` (default 24).
+* **Scope first** – Metadata filters are applied in SQL before the vector KNN
+  call.
+* **Vector search** – Executes `VECTOR_DISTANCE` over the `ESG_DOCS`
+  embedding column (MiniLM 384) using the cosine metric.
+* **Deduplication** – Canonical key is the lowercase of
+  `COALESCE(NORMALIZED_URL, SOURCE_ID, DOC_ID)`. Later duplicates override
+  earlier ones. Near-duplicates collapse when title + hash(first 200 chars)
+  match. Final payload is capped at 6 sources (8 internal facts) with ≤2
+  chunks per source and ≤1 per exact URL.
+* **Outputs** –
+
+  ```json
+  {
+    "facts": [
+      {
+        "citation_id": "FCA_2024_Guidance",
+        "title": "…",
+        "source_name": "FCA",
+        "url": "https://…",
+        "date": "2024-11-18",
+        "snippet": "…"
+      }
+    ],
+    "context_note": "- filters applied: …\n- knn_top_k=24 → dedup=6 → final=6",
+    "latency_ms": 410,
+    "candidates": 24,
+    "deduped": 8
+  }
+  ```
+
+### Output Schema
+
+The Gemini composer returns only two customer-facing fields:
+
+* `answer` – short narrative with inline citations (`[citation_id]`).
+* `sources` – clean list formatted `Title — Publisher (Date)` (3–6 items,
+  deduplicated).
+
+`meta` is preserved for APEX but contains only diagnostics (latency breakdowns,
+retriever context notes, debug toggles). Debug artifacts are available under
+`meta.debug` only when `SHOW_DEBUG_BLOCK=1`.
+
+### Feature Flags
+
+| Flag | Default | Purpose |
+| --- | --- | --- |
+| `GEMINI_FIRST_ENABLED` | `1` | Master switch. Flip to `0` to roll back to the pre-Gemini behaviour without redeploying. |
+| `SHOW_DEBUG_BLOCK` | `0` | Exposes `meta.debug` for the developer “Deep/Debug” toggle. Keep `0` in production. |
+| `ALLOW_HOP2` | `1` | Enables Gemini-requested second-hop retrieval when additional evidence is required. |
+
+Rate limiting is controlled via `ASK2_RATE_WINDOW` (seconds) and
+`ASK2_RATE_MAX` (requests per window). Retrieval caps can be tuned with
+`RETRIEVER_MAX_FACTS`, `RETRIEVER_FACT_CAP`, and `RETRIEVER_PER_SOURCE_CAP`.
+
+### Runbook
+
+* **Run locally**
+
+  ```bash
+  uvicorn app.retrieval.app:app --host 0.0.0.0 --port 8080
+  ```
+
+* **Acceptance checks** – Validate the membership, definition, and controversy
+  scenarios plus small-talk responses. Confirm deduplication by querying with
+  URLs that only differ by tracking parameters. Target end-to-end p50 latency is
+  ≤4.5s (Oracle ≤1.2s, Gemini compose ≤2.5s, remaining glue ≤0.8s).
+
+* **Observability** – Every `/ask2` call logs intent, filters, K values, final
+  source counts, latency breakdowns, and hop counts. A daily “Top-10 Misses”
+  plus Gemini/Oracle usage snapshot is emitted at UTC midnight.
+
+* **Rollback** – Set `GEMINI_FIRST_ENABLED=0` and reload the service. The stack
+  will short-circuit the Gemini planner/composer while preserving the `/ask2`
+  contract.
+
+## Environment
+
+Copy `config/env.sample` and adjust the Oracle wallet location, DB credentials,
+Gemini CLI binary, and API key for your environment. All Gemini interactions
+use the CLI (`gemini`), so make sure the binary is available on `$PATH` or
+override `GEMINI_BIN`.
+

--- a/app.py
+++ b/app.py
@@ -1,5 +1,6 @@
 
 # SustainaCore app.py — SMART v2
+import logging
 import os, re, time, json, requests
 from collections import defaultdict
 from flask import Flask, request, jsonify
@@ -18,6 +19,23 @@ try:
     from app.rag import routing as _ask2_routing  # type: ignore
 except Exception:  # pragma: no cover - defensive import
     _ask2_routing = None
+
+try:  # Gemini-first shared service (optional)
+    from app.retrieval.service import (
+        GeminiUnavailableError as _GeminiUnavailableError,
+        RateLimitError as _GeminiRateLimitError,
+        run_pipeline as _gemini_run_pipeline,
+    )
+    from app.retrieval.settings import settings as _gemini_settings
+except Exception:  # pragma: no cover - optional dependency
+    class _GeminiRateLimitError(Exception):  # type: ignore[no-redef]
+        detail = "rate_limited"
+
+    class _GeminiUnavailableError(Exception):  # type: ignore[no-redef]
+        pass
+
+    _gemini_run_pipeline = None
+    _gemini_settings = None
 
 
 def _sanitize_meta_k(value, default=4):
@@ -53,7 +71,10 @@ else:  # pragma: no cover - import fallback
     )
 
 
-def _call_route_ask2_facade(question: str, k_value):
+_LOGGER = logging.getLogger("app.ask2")
+
+
+def _call_route_ask2_facade(question: str, k_value, *, client_ip: str | None = None):
     """Invoke the smart router with graceful fallbacks.
 
     This mirrors the WSGI facade logic so running ``app.py`` directly (e.g. via
@@ -61,19 +82,61 @@ def _call_route_ask2_facade(question: str, k_value):
     """
 
     sanitized_k = _sanitize_meta_k(k_value)
+    question_text = (question or "").strip()
+
+    if (
+        _gemini_run_pipeline is not None
+        and _gemini_settings is not None
+        and _gemini_settings.gemini_first_enabled
+    ):
+        try:
+            payload = _gemini_run_pipeline(
+                question_text, k=sanitized_k, client_ip=client_ip or "unknown"
+            )
+            meta = payload.get("meta") if isinstance(payload, dict) else None
+            if not isinstance(meta, dict):
+                meta = {}
+            meta.setdefault("k", sanitized_k)
+            payload = {
+                "answer": str(payload.get("answer") or ""),
+                "sources": payload.get("sources") or [],
+                "meta": meta,
+            }
+            return payload, 200
+        except _GeminiRateLimitError as exc:  # type: ignore[arg-type]
+            return (
+                {
+                    "answer": "You’ve hit the current rate limit. Please retry in a few seconds.",
+                    "sources": [],
+                    "meta": {
+                        "error": getattr(exc, "detail", "rate_limited"),
+                        "intent": "RATE_LIMIT",
+                        "k": sanitized_k,
+                        "routing": "gemini_first",
+                        "show_debug_block": False,
+                    },
+                },
+                429,
+            )
+        except _GeminiUnavailableError:  # type: ignore[arg-type]
+            pass  # fall back to legacy router
+        except Exception as exc:  # pragma: no cover - defensive logging
+            _LOGGER.exception("Gemini-first pipeline failed; using legacy router", exc_info=exc)
+
     if callable(_route_ask2):
         try:
-            shaped = _route_ask2(question, sanitized_k)
+            shaped = _route_ask2(question_text, sanitized_k)
             if isinstance(shaped, dict):
                 meta = shaped.get("meta")
                 if isinstance(meta, dict):
                     meta.setdefault("k", sanitized_k)
                 else:
                     shaped["meta"] = {"k": sanitized_k}
-                return shaped
-        except Exception:
-            pass
-    return {
+                return shaped, 200
+        except Exception as exc:  # pragma: no cover - defensive logging
+            _LOGGER.exception("Legacy /ask2 router failed", exc_info=exc)
+
+    fallback = {
         "answer": _ASK2_ROUTER_FALLBACK,
         "sources": [],
         "meta": {
@@ -84,6 +147,7 @@ def _call_route_ask2_facade(question: str, k_value):
             "error": "router_unavailable",
         },
     }
+    return fallback, 200
 
 EMBED_DIM = int(os.getenv("EMBED_DIM", "384"))
 OLLAMA = os.getenv("OLLAMA_URL", "http://127.0.0.1:11434")
@@ -816,8 +880,13 @@ def ask2():
         k_value = args.get('k') or args.get('top_k') or args.get('limit')
 
     question = q_raw.strip() if isinstance(q_raw, str) else ''
-    shaped = _call_route_ask2_facade(question, k_value)
-    return jsonify(shaped), 200
+    forwarded = request.headers.get('X-Forwarded-For', '')
+    if forwarded:
+        client_ip = forwarded.split(',')[0].strip()
+    else:
+        client_ip = request.remote_addr or 'unknown'
+    shaped, status = _call_route_ask2_facade(question, k_value, client_ip=client_ip)
+    return jsonify(shaped), status
 
 
 

--- a/app/retrieval/gemini_gateway.py
+++ b/app/retrieval/gemini_gateway.py
@@ -1,0 +1,459 @@
+"""Thin wrapper around the Gemini CLI for the Gemini-first orchestration."""
+
+from __future__ import annotations
+
+import json
+import logging
+import re
+from typing import Any, Dict, Iterable, List, Optional, Tuple
+from urllib.parse import parse_qsl, urlencode, urlparse, urlunparse
+
+from app.rag.gemini_cli import gemini_call
+
+from .settings import settings
+
+
+LOGGER = logging.getLogger("gemini-gateway")
+
+
+def _parse_json(text: Optional[str]) -> Optional[Dict[str, Any]]:
+    if not text:
+        return None
+    try:
+        return json.loads(text)
+    except json.JSONDecodeError:
+        LOGGER.warning("Gemini response was not valid JSON: %s", text[:2000])
+        return None
+
+
+class GeminiGateway:
+    """Lightweight helper that enforces consistent prompts and parsing."""
+
+    def __init__(self) -> None:
+        self._timeout = settings.gemini_timeout
+
+    def _call_json(self, prompt: str, *, model: str) -> Optional[Dict[str, Any]]:
+        text = gemini_call(prompt, timeout=self._timeout, model=model)
+        return _parse_json(text)
+
+    # ---- public API -----------------------------------------------------
+
+    def classify_intent(self, question: str) -> Dict[str, Any]:
+        """Return a structured intent classification."""
+
+        prompt = (
+            "You are SustainaCore's Gemini front-door classifier.\n"
+            "Decide whether the user input is SMALL_TALK or INFO_REQUEST.\n"
+            "SMALL_TALK covers greetings, thanks, compliments, or casual chit-chat.\n"
+            "INFO_REQUEST is any request that needs grounded facts about TECH100, ESG, or AI governance.\n"
+            "Return ONLY valid compact JSON with keys intent, confidence (0-1), and rationale.\n"
+            "Example: {\"intent\": \"SMALL_TALK\", \"confidence\": 0.62, \"rationale\": \"greeting\"}.\n"
+            f"User input: {question.strip()}\n"
+        )
+
+        payload = self._call_json(prompt, model=settings.gemini_model_intent) or {}
+        intent = str(payload.get("intent") or "INFO_REQUEST").strip().upper()
+        if intent not in {"SMALL_TALK", "INFO_REQUEST"}:
+            intent = "INFO_REQUEST"
+        confidence = payload.get("confidence")
+        try:
+            confidence = float(confidence)
+        except (TypeError, ValueError):
+            confidence = None
+        rationale = str(payload.get("rationale") or "").strip()
+        return {"intent": intent, "confidence": confidence, "rationale": rationale, "raw": payload}
+
+    def plan_retrieval(self, question: str) -> Dict[str, Any]:
+        """Ask Gemini for a retrieval plan."""
+
+        prompt = (
+            "You are the retrieval planner for SustainaCore's Gemini-first pipeline.\n"
+            "Craft Oracle 23ai vector search instructions for the question below.\n"
+            "Return ONLY JSON with keys: filters (object), query_variants (3-5 strings), k (int), and optional hop2.\n"
+            "filters must stick to supported keys: SOURCE_TYPE, TICKER, DATE_FROM, DATE_TO, DOC_ID, SOURCE_ID.\n"
+            "Use upper-case keys and lists for multi-value filters.\n"
+            "Ensure query_variants preserve key nouns and abbreviations.\n"
+            "Set k to 24 unless a smaller slice is strongly justified.\n"
+            "hop2 is optional and may include reason, filters, and query_variants when a second retrieval hop is essential.\n"
+            "Never include prose outside the JSON payload.\n"
+            f"Question: {question.strip()}\n"
+        )
+
+        plan = self._call_json(prompt, model=settings.gemini_model_plan) or {}
+        variants = plan.get("query_variants")
+        if not isinstance(variants, list):
+            variants = [question.strip()]
+        cleaned_variants: List[str] = []
+        for variant in variants:
+            if not isinstance(variant, str):
+                continue
+            variant = variant.strip()
+            if not variant:
+                continue
+            if variant not in cleaned_variants:
+                cleaned_variants.append(variant)
+            if len(cleaned_variants) >= 5:
+                break
+        if not cleaned_variants:
+            cleaned_variants = [question.strip()]
+        filters = plan.get("filters")
+        filters = filters if isinstance(filters, dict) else {}
+        upper_filters = {}
+        for key, value in filters.items():
+            if not isinstance(key, str):
+                continue
+            key_u = key.strip().upper()
+            if key_u not in settings.oracle_scope_filters:
+                continue
+            if isinstance(value, list):
+                normalized_list = []
+                for item in value:
+                    if isinstance(item, str) and item.strip():
+                        normalized_list.append(item.strip())
+                if normalized_list:
+                    upper_filters[key_u] = normalized_list
+            elif isinstance(value, str) and value.strip():
+                upper_filters[key_u] = value.strip()
+        k_value = plan.get("k")
+        try:
+            k_int = int(k_value)
+        except (TypeError, ValueError):
+            k_int = settings.oracle_knn_k
+        if k_int <= 0 or k_int > 64:
+            k_int = settings.oracle_knn_k
+        hop2 = plan.get("hop2") if isinstance(plan.get("hop2"), dict) else None
+        if hop2:
+            hop2_filters = hop2.get("filters") if isinstance(hop2.get("filters"), dict) else {}
+            normalized_hop2_filters = {}
+            for key, value in hop2_filters.items():
+                if isinstance(key, str):
+                    key_u = key.strip().upper()
+                    if key_u in settings.oracle_scope_filters:
+                        normalized_hop2_filters[key_u] = value
+            hop2_variants_raw = hop2.get("query_variants") if isinstance(hop2.get("query_variants"), list) else []
+            hop2_variants: List[str] = []
+            for item in hop2_variants_raw:
+                if isinstance(item, str):
+                    item = item.strip()
+                    if item and item not in hop2_variants:
+                        hop2_variants.append(item)
+            hop2_data = {
+                "reason": hop2.get("reason"),
+                "filters": normalized_hop2_filters,
+                "query_variants": hop2_variants[:5],
+            }
+        else:
+            hop2_data = None
+
+        return {
+            "filters": upper_filters,
+            "query_variants": cleaned_variants,
+            "k": k_int,
+            "hop2": hop2_data,
+            "raw": plan,
+        }
+
+    def compose_small_talk(self, question: str) -> str:
+        prompt = (
+            "You are SustainaCore's assistant. Provide a short, warm reply (1-2 sentences) to the user input below.\n"
+            "Do NOT add citations or mention sources.\n"
+            "Keep it natural and contextual.\n"
+            "Return ONLY the reply text as JSON: {\"answer\": \"...\"}.\n"
+            f"User input: {question.strip()}"
+        )
+        payload = self._call_json(prompt, model=settings.gemini_model_answer) or {}
+        answer = payload.get("answer") if isinstance(payload, dict) else None
+        if not isinstance(answer, str) or not answer.strip():
+            return "Happy to help!"
+        return answer.strip()
+
+    def compose_answer(
+        self,
+        question: str,
+        retriever_result: Dict[str, Any],
+        plan: Dict[str, Any],
+        hop_count: int,
+    ) -> Dict[str, Any]:
+        """Ask Gemini to generate the final answer using retrieved facts."""
+
+        payload = {
+            "question": question.strip(),
+            "plan": {k: v for k, v in plan.items() if k != "raw"},
+            "retriever_result": retriever_result,
+            "hop_count": hop_count,
+            "instructions": {
+                "style": "≤1 short paragraph + optional bullets; friendly and precise",
+                "citations": "inline using [citation_id]",
+                "no_debug": True,
+                "max_sources": settings.retriever_fact_cap,
+                "prohibited_openers": [
+                    "Here’s the best supported answer",
+                    "Here's the best supported answer",
+                    "Why this answer",
+                ],
+            },
+        }
+        prompt = (
+            "You are the Gemini composer for SustainaCore.\n"
+            "Use ONLY the facts in retriever_result.facts to answer the question.\n"
+            "Every claim referencing retrieved evidence must include an inline citation like [FCA_2024_Guidance].\n"
+            "Do not invent citation ids or facts.\n"
+            "Keep the tone confident, concise, and human.\n"
+            "Do not prefix the answer with explanations such as 'Here’s the best supported answer' or 'Why this answer'.\n"
+            "Return ONLY JSON with keys: answer (string) and sources (array of strings formatted 'Title — Publisher (Date)').\n"
+            "Do not include debug sections, numbered sources, or redundant source listings in the answer body.\n"
+            f"Payload: {json.dumps(payload, ensure_ascii=False)}"
+        )
+        response = self._call_json(prompt, model=settings.gemini_model_answer) or {}
+        answer = response.get("answer") if isinstance(response, dict) else None
+        if not isinstance(answer, str):
+            answer = "I’m sorry, I couldn’t generate an answer from the retrieved facts."
+        cleaned_answer = _clean_answer_text(answer)
+
+        facts = retriever_result.get("facts") if isinstance(retriever_result, dict) else None
+        derived_sources = _build_sources_from_facts(
+            cleaned_answer, facts if isinstance(facts, list) else [], settings.retriever_fact_cap
+        )
+
+        if not derived_sources:
+            sources = response.get("sources") if isinstance(response, dict) else None
+            if not isinstance(sources, list):
+                sources = []
+            raw_sources: List[str] = []
+            for item in sources:
+                if isinstance(item, str):
+                    candidate = item.strip()
+                    if candidate:
+                        raw_sources.append(candidate)
+                elif isinstance(item, dict):
+                    display = item.get("display") or item.get("title") or ""
+                    if isinstance(display, str):
+                        candidate = display.strip()
+                        if candidate:
+                            raw_sources.append(candidate)
+            derived_sources = _dedup_sources(raw_sources, settings.retriever_fact_cap)
+
+        final_sources = _dedup_sources(derived_sources, settings.retriever_fact_cap)
+
+        return {"answer": cleaned_answer, "sources": final_sources, "raw": response}
+
+
+gateway = GeminiGateway()
+
+
+def _clean_answer_text(answer: str) -> str:
+    """Remove boilerplate/debug headings from Gemini answers."""
+
+    if not isinstance(answer, str):
+        return ""
+
+    text = answer.strip()
+    if not text:
+        return ""
+
+    banned_prefixes = (
+        "here’s the best supported answer",
+        "here's the best supported answer",
+    )
+    lines = [line.rstrip() for line in text.splitlines()]
+    cleaned: List[str] = []
+    skip_debug = False
+    removed_any = False
+
+    for raw_line in lines:
+        line = raw_line.strip()
+        normalized = line.lower()
+
+        if not line:
+            if skip_debug:
+                skip_debug = False
+                removed_any = True
+                continue
+            if cleaned and cleaned[-1]:
+                cleaned.append("")
+            continue
+
+        if any(normalized.startswith(prefix) for prefix in banned_prefixes):
+            removed_any = True
+            continue
+
+        if normalized.startswith("why this answer") or normalized.startswith("sources"):
+            skip_debug = True
+            removed_any = True
+            continue
+
+        if normalized.startswith("source ") and ":" in normalized:
+            removed_any = True
+            continue
+
+        if normalized.startswith("- source "):
+            removed_any = True
+            continue
+
+        if skip_debug:
+            removed_any = True
+            continue
+
+        cleaned.append(line)
+
+    collapsed = re.sub(r"(\n\s*){2,}", "\n\n", "\n".join(cleaned)).strip()
+    if collapsed:
+        return collapsed
+
+    return "" if removed_any else text
+
+
+def _dedup_sources(sources: Iterable[str], limit: int) -> List[str]:
+    """Deduplicate source displays while keeping the last occurrence."""
+
+    normalized: List[Tuple[str, str]] = []
+    last_index: Dict[str, int] = {}
+
+    for item in sources:
+        key = _normalize_source_key(item)
+        if not key:
+            continue
+        normalized.append((key, item))
+        last_index[key] = len(normalized) - 1
+
+    deduped: List[str] = []
+    for idx, (key, original) in enumerate(normalized):
+        if last_index.get(key) != idx:
+            continue
+        deduped.append(original)
+        if len(deduped) >= max(0, limit):
+            break
+
+    return deduped
+
+
+def _normalize_source_key(value: str) -> str:
+    if not isinstance(value, str):
+        return ""
+    text = value.strip()
+    if not text:
+        return ""
+    normalized = re.sub(r"\s+", " ", text)
+    return normalized.strip().lower()
+
+
+_CITATION_PATTERN = re.compile(r"\[\s*([A-Za-z0-9._:-]+)\s*\]")
+
+
+def _extract_citation_ids(answer: str) -> List[str]:
+    if not isinstance(answer, str) or not answer:
+        return []
+    ids: List[str] = []
+    for match in _CITATION_PATTERN.finditer(answer):
+        citation = match.group(1).strip()
+        if citation:
+            ids.append(citation)
+    return ids
+
+
+def _build_sources_from_facts(
+    answer: str, facts: Iterable[Dict[str, Any]], limit: int
+) -> List[str]:
+    if limit <= 0:
+        return []
+
+    citation_ids = _extract_citation_ids(answer)
+    key_to_entry: Dict[str, Dict[str, Any]] = {}
+    citation_to_key: Dict[str, str] = {}
+    ordered_entries: List[Tuple[str, Dict[str, Any]]] = []
+
+    for idx, fact in enumerate(facts or []):
+        if not isinstance(fact, dict):
+            continue
+        canonical_key = _canonical_fact_key(fact)
+        if not canonical_key:
+            continue
+        entry = {"fact": fact, "index": idx}
+        key_to_entry[canonical_key] = entry
+        ordered_entries.append((canonical_key, entry))
+        citation_id = str(fact.get("citation_id") or "").strip()
+        if citation_id:
+            citation_to_key[citation_id.lower()] = canonical_key
+
+    ordered_keys: List[str] = []
+    seen_keys: set[str] = set()
+
+    for citation in citation_ids:
+        key = citation_to_key.get(citation.lower())
+        if key and key in key_to_entry and key not in seen_keys:
+            ordered_keys.append(key)
+            seen_keys.add(key)
+
+    for canonical_key, entry in ordered_entries:
+        if key_to_entry.get(canonical_key) is entry and canonical_key not in seen_keys:
+            ordered_keys.append(canonical_key)
+            seen_keys.add(canonical_key)
+
+    sources: List[str] = []
+    for canonical_key in ordered_keys:
+        entry = key_to_entry.get(canonical_key)
+        if not entry:
+            continue
+        display = _format_source_display(entry["fact"])
+        if not display:
+            continue
+        sources.append(display)
+        if len(sources) >= limit:
+            break
+
+    return sources
+
+
+def _canonical_fact_key(fact: Dict[str, Any]) -> str:
+    url = fact.get("url")
+    if isinstance(url, str) and url.strip():
+        normalized = _normalize_url(url)
+        if normalized:
+            return normalized
+    for key in ("citation_id", "doc_id", "source_id"):
+        value = fact.get(key)
+        if isinstance(value, str) and value.strip():
+            return value.strip().lower()
+    title = fact.get("title")
+    if isinstance(title, str) and title.strip():
+        return title.strip().lower()
+    return ""
+
+
+def _format_source_display(fact: Dict[str, Any]) -> str:
+    title = str(fact.get("title") or "").strip() or "Untitled excerpt"
+    source = str(fact.get("source_name") or "").strip()
+    date = fact.get("date")
+    date_text = str(date).strip() if isinstance(date, str) else ""
+    display = title
+    if source:
+        display = f"{display} — {source}"
+    if date_text:
+        display = f"{display} ({date_text})"
+    return display.strip()
+
+
+def _normalize_url(url: str) -> str:
+    try:
+        parsed = urlparse(url)
+    except Exception:
+        return url.strip().lower()
+    filtered_params = [
+        (k, v)
+        for k, v in parse_qsl(parsed.query, keep_blank_values=False)
+        if not k.lower().startswith(("utm_", "session", "ref", "fbclid", "gclid"))
+    ]
+    query = urlencode(filtered_params, doseq=True)
+    sanitized = parsed._replace(query=query, fragment="")
+    if sanitized.scheme in {"http", "https"}:
+        sanitized = sanitized._replace(netloc=sanitized.netloc.lower())
+    return urlunparse(sanitized)
+
+
+__all__ = [
+    "gateway",
+    "_clean_answer_text",
+    "_dedup_sources",
+    "_build_sources_from_facts",
+]
+

--- a/app/retrieval/observability.py
+++ b/app/retrieval/observability.py
@@ -1,0 +1,61 @@
+"""Observability helpers for the Gemini-first orchestration."""
+
+from __future__ import annotations
+
+import datetime as _dt
+import json
+import logging
+import threading
+from collections import Counter
+from typing import Any, Dict
+
+
+LOGGER = logging.getLogger("observability")
+
+
+class Observability:
+    """Collects per-request telemetry and emits a daily snapshot."""
+
+    def __init__(self) -> None:
+        self._lock = threading.Lock()
+        self._day = _dt.date.today()
+        self._misses: Counter[str] = Counter()
+        self._usage: Counter[str] = Counter()
+
+    def _emit_daily(self) -> None:
+        top_misses = self._misses.most_common(10)
+        payload = {
+            "event": "daily_report",
+            "day": self._day.isoformat(),
+            "top_10_misses": top_misses,
+            "usage_snapshot": dict(self._usage),
+        }
+        LOGGER.info(json.dumps(payload, ensure_ascii=False))
+
+    def _rollover_if_needed(self) -> None:
+        today = _dt.date.today()
+        if today != self._day:
+            self._emit_daily()
+            self._day = today
+            self._misses.clear()
+            self._usage.clear()
+
+    def record(self, record: Dict[str, Any]) -> None:
+        payload = dict(record)
+        with self._lock:
+            self._rollover_if_needed()
+            question = payload.get("question") or ""
+            if payload.get("final_sources_count", 0) == 0 and question:
+                key = str(question)[:160]
+                self._misses[key] += 1
+            intent = payload.get("intent") or "INFO_REQUEST"
+            self._usage[f"intent:{intent}"] += 1
+            if payload.get("intent") == "INFO_REQUEST":
+                self._usage["oracle_calls"] += 1
+            if payload.get("gemini"):
+                self._usage[f"gemini:{payload['gemini']}"] += 1
+            LOGGER.info(json.dumps(payload, ensure_ascii=False))
+
+
+observer = Observability()
+

--- a/app/retrieval/oracle_retriever.py
+++ b/app/retrieval/oracle_retriever.py
@@ -1,0 +1,486 @@
+"""Oracle 23ai retriever that honours the Gemini-first contract."""
+
+from __future__ import annotations
+
+import datetime as _dt
+import hashlib
+import json
+import logging
+import os
+import time
+from dataclasses import dataclass
+from typing import Any, Dict, Iterable, List, Optional, Sequence, Tuple
+from urllib.parse import parse_qsl, urlencode, urlparse, urlunparse
+
+import oracledb
+
+from .settings import settings
+
+
+LOGGER = logging.getLogger("oracle-retriever")
+
+
+def _read_env_file_var(path: str, key: str) -> Optional[str]:
+    try:
+        with open(path, "r", encoding="utf-8") as handle:
+            for line in handle:
+                line = line.strip()
+                if not line or line.startswith("#"):
+                    continue
+                k, _, v = line.partition("=")
+                if k.strip() == key:
+                    return v.strip()
+    except OSError:
+        return None
+    return None
+
+
+def _connection() -> oracledb.Connection:
+    password = (
+        os.environ.get("DB_PASSWORD")
+        or os.environ.get("DB_PASS")
+        or os.environ.get("DB_PWD")
+        or _read_env_file_var("/etc/sustainacore/db.env", "DB_PASSWORD")
+    )
+    return oracledb.connect(
+        user=os.environ.get("DB_USER", "WKSP_ESGAPEX"),
+        password=password,
+        dsn=os.environ.get("DB_DSN", "dbri4x6_high"),
+        config_dir=os.environ.get("TNS_ADMIN", "/opt/adb_wallet"),
+        wallet_location=os.environ.get("TNS_ADMIN", "/opt/adb_wallet"),
+        wallet_password=os.environ.get("WALLET_PWD"),
+    )
+
+
+def _normalize_url(url: Optional[str]) -> Optional[str]:
+    if not url:
+        return None
+    try:
+        parsed = urlparse(url)
+    except Exception:
+        return url
+    filtered_params = [
+        (k, v)
+        for k, v in parse_qsl(parsed.query, keep_blank_values=False)
+        if not k.lower().startswith(("utm_", "session", "ref", "fbclid", "gclid"))
+    ]
+    normalized_query = urlencode(filtered_params, doseq=True)
+    sanitized = parsed._replace(query=normalized_query, fragment="")
+    if sanitized.scheme in {"http", "https"}:
+        sanitized = sanitized._replace(netloc=sanitized.netloc.lower())
+    return urlunparse(sanitized)
+
+
+def _infer_source_name(url: Optional[str]) -> str:
+    if not url:
+        return ""
+    try:
+        parsed = urlparse(url)
+    except Exception:
+        return ""
+    host = parsed.netloc.lower()
+    return host.split(":", 1)[0]
+
+
+def _to_plain(value: Any) -> Any:
+    if hasattr(value, "read"):
+        try:
+            return value.read()
+        except Exception:  # pragma: no cover - defensive
+            return str(value)
+    if isinstance(value, oracledb.Vector):  # type: ignore[attr-defined]
+        return list(value)
+    return value
+
+
+def _safe_date(value: Any) -> Optional[str]:
+    if value is None:
+        return None
+    if isinstance(value, _dt.datetime):
+        return value.date().isoformat()
+    if isinstance(value, _dt.date):
+        return value.isoformat()
+    if isinstance(value, str):
+        text = value.strip()
+        if not text:
+            return None
+        for fmt in ("%Y-%m-%d", "%Y/%m/%d", "%d-%b-%Y", "%Y-%m", "%Y"):
+            try:
+                parsed = _dt.datetime.strptime(text[:len(fmt)], fmt)
+                return parsed.date().isoformat()
+            except ValueError:
+                continue
+        return text
+    return str(value)
+
+
+def _score_from_distance(distance: Any) -> Optional[float]:
+    try:
+        dist = float(distance)
+    except (TypeError, ValueError):
+        return None
+    if dist != dist:  # NaN check
+        return None
+    score = 1.0 - dist
+    if score > 1.0:
+        score = 1.0
+    if score < 0.0:
+        score = 0.0
+    return round(score, 4)
+
+
+@dataclass
+class RetrievalResult:
+    facts: List[Dict[str, Any]]
+    context_note: str
+    latency_ms: int
+    candidates: int
+    deduped: int
+    hop_count: int
+    raw_facts: Optional[List[Dict[str, Any]]] = None
+
+
+class OracleRetriever:
+    """Implements the Oracle retriever contract for Gemini."""
+
+    def __init__(self) -> None:
+        self.table = settings.oracle_table.upper()
+        self.embedding_column = settings.oracle_embedding_column.upper()
+        self.text_column = settings.oracle_text_column.upper()
+        self.url_column = settings.oracle_url_column.upper()
+        self.norm_url_column = settings.oracle_normalized_url_column.upper()
+        self.title_column = settings.oracle_title_column.upper()
+        self.source_column = settings.oracle_source_column.upper()
+        self.date_column = settings.oracle_date_column.upper()
+        self.doc_id_column = settings.oracle_doc_id_column.upper()
+        self.source_id_column = settings.oracle_source_id_column.upper()
+        self.chunk_ix_column = settings.oracle_chunk_ix_column.upper()
+        self.metric = settings.oracle_knn_metric
+        self._available_columns: set[str] = set()
+        self._refresh_columns()
+        self._verify_embeddings()
+
+    # ---- metadata helpers -------------------------------------------------
+
+    def _refresh_columns(self) -> None:
+        try:
+            with _connection() as conn:
+                owner = conn.username.upper()
+                try:
+                    cur = conn.cursor()
+                    cur.execute(
+                        "SELECT column_name FROM ALL_TAB_COLUMNS WHERE OWNER = :owner AND TABLE_NAME = :table",
+                        owner=owner,
+                        table=self.table,
+                    )
+                    cols = [row[0].upper() for row in cur]
+                except oracledb.DatabaseError:
+                    cur = conn.cursor()
+                    cur.execute("SELECT column_name FROM USER_TAB_COLUMNS WHERE TABLE_NAME = :table", table=self.table)
+                    cols = [row[0].upper() for row in cur]
+        except Exception as exc:  # pragma: no cover - requires DB
+            LOGGER.warning("Failed to introspect Oracle columns: %s", exc)
+            cols = []
+        self._available_columns = set(cols)
+
+    def _has_column(self, column: str) -> bool:
+        return column.upper() in self._available_columns
+
+    def _verify_embeddings(self) -> None:
+        if not self._has_column(self.embedding_column):
+            LOGGER.warning("Embedding column %s not found in %s", self.embedding_column, self.table)
+            return
+        try:
+            with _connection() as conn:
+                cur = conn.cursor()
+                query = (
+                    f"SELECT MIN(vector_dims({self.embedding_column})), MAX(vector_dims({self.embedding_column})) "
+                    f"FROM {self.table}"
+                )
+                cur.execute(query)
+                row = cur.fetchone()
+                if not row:
+                    return
+                min_dim, max_dim = row
+                if min_dim != max_dim:
+                    LOGGER.warning("Embedding dimensions vary across rows: min=%s max=%s", min_dim, max_dim)
+                if max_dim and int(max_dim) != 384:
+                    LOGGER.warning("Expected 384-dim embeddings, got %s", max_dim)
+        except Exception as exc:  # pragma: no cover - requires DB
+            LOGGER.warning("Could not verify embedding dimensions: %s", exc)
+
+    # ---- embedding --------------------------------------------------------
+
+    def _embed(self, conn: oracledb.Connection, text: str) -> Optional[Sequence[float]]:
+        text = (text or "").strip()
+        if not text:
+            return None
+        try:
+            cur = conn.cursor()
+            sql = settings.oracle_embed_sql
+            binds = {"model": settings.oracle_embed_model, "text": text}
+            cur.execute(sql, binds)
+            row = cur.fetchone()
+            if not row:
+                return None
+            vec = _to_plain(row[0])
+            if isinstance(vec, (list, tuple)):
+                return [float(x) for x in vec]
+        except Exception as exc:  # pragma: no cover - requires DB
+            LOGGER.error("Oracle embed failed: %s", exc)
+        return None
+
+    # ---- SQL construction -------------------------------------------------
+
+    def _build_filter_clause(self, filters: Dict[str, Any], binds: Dict[str, Any]) -> str:
+        clauses: List[str] = []
+        counter = 0
+        for key, value in (filters or {}).items():
+            if not key:
+                continue
+            key_u = key.upper()
+            if key_u == "SOURCE_TYPE" and self._has_column("SOURCE_TYPE"):
+                values = value if isinstance(value, list) else [value]
+                clean = [str(v).strip() for v in values if str(v).strip()]
+                if clean:
+                    names = []
+                    for item in clean:
+                        bind = f"p{counter}"; counter += 1
+                        binds[bind] = item
+                        names.append(f":{bind}")
+                    clauses.append("UPPER(SOURCE_TYPE) IN (" + ",".join(names) + ")")
+            elif key_u == "TICKER" and self._has_column("TICKER"):
+                values = value if isinstance(value, list) else [value]
+                clean = [str(v).strip().upper() for v in values if str(v).strip()]
+                if clean:
+                    names = []
+                    for item in clean:
+                        bind = f"p{counter}"; counter += 1
+                        binds[bind] = item
+                        names.append(f":{bind}")
+                    clauses.append("UPPER(TICKER) IN (" + ",".join(names) + ")")
+            elif key_u == "DOC_ID" and self._has_column(self.doc_id_column):
+                bind = f"p{counter}"; counter += 1
+                binds[bind] = str(value)
+                clauses.append(f"{self.doc_id_column} = :{bind}")
+            elif key_u == "SOURCE_ID" and self._has_column(self.source_id_column):
+                bind = f"p{counter}"; counter += 1
+                binds[bind] = str(value)
+                clauses.append(f"{self.source_id_column} = :{bind}")
+            elif key_u == "DATE_FROM" and self._has_column(self.date_column):
+                bind = f"p{counter}"; counter += 1
+                binds[bind] = str(value)
+                clauses.append(f"{self.date_column} >= TO_DATE(:{bind}, 'YYYY-MM-DD')")
+            elif key_u == "DATE_TO" and self._has_column(self.date_column):
+                bind = f"p{counter}"; counter += 1
+                binds[bind] = str(value)
+                clauses.append(f"{self.date_column} <= TO_DATE(:{bind}, 'YYYY-MM-DD')")
+        return (" AND ".join(clauses)) if clauses else ""
+
+    def _select_clause(self) -> str:
+        cols: List[str] = []
+        if self._has_column(self.doc_id_column):
+            cols.append(f"{self.doc_id_column} AS DOC_ID")
+        if self._has_column(self.chunk_ix_column):
+            cols.append(f"{self.chunk_ix_column} AS CHUNK_IX")
+        if self._has_column(self.source_id_column):
+            cols.append(f"{self.source_id_column} AS SOURCE_ID")
+        if self._has_column(self.source_column):
+            cols.append(f"{self.source_column} AS SOURCE_NAME")
+        if self._has_column(self.title_column):
+            cols.append(f"{self.title_column} AS TITLE")
+        if self._has_column(self.url_column):
+            cols.append(f"{self.url_column} AS SOURCE_URL")
+        if self._has_column(self.norm_url_column):
+            cols.append(f"{self.norm_url_column} AS NORMALIZED_URL")
+        if self._has_column(self.date_column):
+            cols.append(f"{self.date_column} AS PUBLISHED_DATE")
+        if self._has_column(self.text_column):
+            cols.append(f"{self.text_column} AS CHUNK_TEXT")
+        cols.append(
+            f"VECTOR_DISTANCE({self.embedding_column}, :vec, '{self.metric}') AS DIST"
+        )
+        return ", ".join(cols)
+
+    def _vector_query(
+        self,
+        conn: oracledb.Connection,
+        embedding: Sequence[float],
+        filters: Dict[str, Any],
+        k: int,
+    ) -> List[Dict[str, Any]]:
+        binds: Dict[str, Any] = {}
+        filter_clause = self._build_filter_clause(filters, binds)
+        where = f"WHERE {filter_clause}" if filter_clause else ""
+        sql = (
+            f"SELECT {self._select_clause()} FROM {self.table} {where} "
+            f"ORDER BY VECTOR_DISTANCE({self.embedding_column}, :vec, '{self.metric}') "
+            "FETCH FIRST :k ROWS ONLY"
+        )
+        cur = conn.cursor()
+        cur.setinputsizes(vec=oracledb.DB_TYPE_VECTOR)
+        binds.update({"vec": embedding, "k": int(k)})
+        cur.execute(sql, binds)
+        columns = [desc[0].lower() for desc in cur.description]
+        rows: List[Dict[str, Any]] = []
+        for raw in cur.fetchall():
+            row = {col: _to_plain(value) for col, value in zip(columns, raw)}
+            if "normalized_url" not in row or not row["normalized_url"]:
+                row["normalized_url"] = _normalize_url(row.get("source_url"))
+            rows.append(row)
+        return rows
+
+    # ---- deduplication ----------------------------------------------------
+
+    @staticmethod
+    def _canonical_key(row: Dict[str, Any]) -> str:
+        for key in ("normalized_url", "source_id", "doc_id"):
+            value = row.get(key)
+            if isinstance(value, str) and value.strip():
+                return value.strip().lower()
+        chunk = row.get("chunk_ix")
+        if chunk is not None and row.get("doc_id"):
+            return f"{row.get('doc_id')}::{chunk}"
+        return hashlib.sha1(json.dumps(row, sort_keys=True).encode("utf-8")).hexdigest()
+
+    def _deduplicate_rows(self, rows: Sequence[Dict[str, Any]]) -> List[Dict[str, Any]]:
+        if not rows:
+            return []
+        last_index: Dict[str, int] = {}
+        for idx, row in enumerate(rows):
+            last_index[self._canonical_key(row)] = idx
+        ordered: List[Dict[str, Any]] = []
+        seen_idx = set()
+        for idx, row in enumerate(rows):
+            key = self._canonical_key(row)
+            if last_index.get(key) != idx:
+                continue
+            if idx in seen_idx:
+                continue
+            ordered.append(row)
+            seen_idx.add(idx)
+        near_seen: Dict[Tuple[str, str], int] = {}
+        collapsed: List[Dict[str, Any]] = []
+        for row in ordered:
+            title = (row.get("title") or "").strip().lower()
+            snippet = (row.get("chunk_text") or "")[:200]
+            snippet_hash = hashlib.sha1(snippet.encode("utf-8", "ignore")).hexdigest() if snippet else ""
+            dedup_key = (title, snippet_hash)
+            if dedup_key in near_seen:
+                collapsed[near_seen[dedup_key]] = row
+            else:
+                near_seen[dedup_key] = len(collapsed)
+                collapsed.append(row)
+        limited: List[Dict[str, Any]] = []
+        per_source: Dict[str, int] = {}
+        per_url: Dict[str, int] = {}
+        for row in collapsed:
+            source_key = str(row.get("source_id") or row.get("source_name") or "").lower()
+            url_key = str(row.get("normalized_url") or row.get("source_url") or "").lower()
+            if source_key:
+                if per_source.get(source_key, 0) >= settings.retriever_per_source_cap:
+                    continue
+            if url_key:
+                if per_url.get(url_key, 0) >= 1:
+                    continue
+            limited.append(row)
+            if source_key:
+                per_source[source_key] = per_source.get(source_key, 0) + 1
+            if url_key:
+                per_url[url_key] = 1
+            if len(limited) >= settings.retriever_max_facts:
+                break
+        return limited
+
+    # ---- facts ------------------------------------------------------------
+
+    def _row_to_fact(self, row: Dict[str, Any], idx: int) -> Dict[str, Any]:
+        citation_source = (
+            row.get("source_id")
+            or row.get("doc_id")
+            or row.get("normalized_url")
+            or row.get("source_url")
+            or f"FACT_{idx+1}"
+        )
+        citation = "".join(ch for ch in str(citation_source) if ch.isalnum() or ch in "-_")
+        if not citation:
+            citation = f"FACT_{idx+1}"
+        snippet = (row.get("chunk_text") or "").strip()
+        if snippet:
+            snippet = " ".join(snippet.split())[:600]
+        source_name = (row.get("source_name") or "").strip() or _infer_source_name(row.get("normalized_url") or row.get("source_url")))
+        fact = {
+            "citation_id": citation,
+            "title": (row.get("title") or "").strip() or "Untitled excerpt",
+            "source_name": source_name or "",
+            "url": row.get("normalized_url") or row.get("source_url"),
+            "date": _safe_date(row.get("published_date")),
+            "snippet": snippet,
+            "score": _score_from_distance(row.get("dist")),
+        }
+        return fact
+
+    def _build_context_note(
+        self,
+        filters: Dict[str, Any],
+        k: int,
+        candidates: int,
+        dedup_count: int,
+        final_count: int,
+    ) -> str:
+        parts: List[str] = []
+        if filters:
+            formatted = ", ".join(
+                f"{key}={value}" for key, value in filters.items() if value
+            )
+            parts.append(f"- filters applied: {formatted}")
+        parts.append(f"- knn_top_k={k} → dedup={dedup_count} → final={final_count}")
+        parts.append(f"- oracle_candidates={candidates}")
+        return "\n".join(parts)
+
+    # ---- public API -------------------------------------------------------
+
+    def retrieve(
+        self,
+        filters: Dict[str, Any],
+        query_variants: Iterable[str],
+        k: int,
+        hop_count: int = 1,
+    ) -> RetrievalResult:
+        start = time.time()
+        k_eff = max(1, min(int(k or settings.oracle_knn_k), 64))
+        rows: List[Dict[str, Any]] = []
+        variants = [v for v in query_variants if isinstance(v, str) and v.strip()]
+        if not variants:
+            variants = [""]
+        try:
+            with _connection() as conn:
+                for variant in variants:
+                    embedding = self._embed(conn, variant)
+                    if embedding is None:
+                        LOGGER.warning("Failed to embed variant: %s", variant)
+                        continue
+                    chunk_rows = self._vector_query(conn, embedding, filters, k_eff)
+                    rows.extend(chunk_rows)
+        except Exception as exc:  # pragma: no cover - requires DB
+            LOGGER.error("Oracle retrieval failed: %s", exc)
+            rows = []
+        deduped = self._deduplicate_rows(rows)
+        facts = [self._row_to_fact(row, idx) for idx, row in enumerate(deduped[: settings.retriever_fact_cap])]
+        context_note = self._build_context_note(filters, k_eff, len(rows), len(deduped), len(facts))
+        latency_ms = int((time.time() - start) * 1000)
+        raw = deduped if settings.show_debug_block else None
+        return RetrievalResult(
+            facts=facts,
+            context_note=context_note,
+            latency_ms=latency_ms,
+            candidates=len(rows),
+            deduped=len(deduped),
+            hop_count=hop_count,
+            raw_facts=raw,
+        )
+
+
+retriever = OracleRetriever()
+
+

--- a/app/retrieval/service.py
+++ b/app/retrieval/service.py
@@ -1,0 +1,302 @@
+"""Shared Gemini-first orchestration helpers used by multiple entrypoints."""
+
+from __future__ import annotations
+
+import logging
+import time
+from collections import deque
+from threading import Lock
+from typing import Any, Dict, Iterable, List, Optional
+
+from .gemini_gateway import gateway
+from .observability import observer
+from .oracle_retriever import retriever
+from .settings import settings
+
+
+LOGGER = logging.getLogger("gemini-service")
+
+
+class RateLimitError(Exception):
+    """Raised when the caller exceeds the configured rate limit."""
+
+    def __init__(self, detail: str = "rate_limited") -> None:
+        super().__init__(detail)
+        self.detail = detail
+
+
+class GeminiUnavailableError(Exception):
+    """Raised when Gemini-first orchestration is disabled or fails hard."""
+
+
+_RATE_BUCKETS: Dict[str, deque] = {}
+_RATE_LOCK = Lock()
+
+
+def _enforce_rate_limit(ip: str) -> None:
+    window = settings.rate_limit_window_seconds
+    limit = settings.rate_limit_max_requests
+    now = time.time()
+    with _RATE_LOCK:
+        bucket = _RATE_BUCKETS.setdefault(ip, deque())
+        while bucket and now - bucket[0] > window:
+            bucket.popleft()
+        if len(bucket) >= limit:
+            raise RateLimitError()
+        bucket.append(now)
+
+
+def _merge_facts(
+    facts_primary: Iterable[Dict[str, Any]], facts_secondary: Iterable[Dict[str, Any]]
+) -> List[Dict[str, Any]]:
+    combined = list(facts_primary) + list(facts_secondary)
+    if not combined:
+        return []
+    last_index: Dict[str, int] = {}
+    keys: List[str] = []
+    for idx, fact in enumerate(combined):
+        key = (fact.get("url") or fact.get("citation_id") or str(idx)).lower()
+        last_index[key] = idx
+        keys.append(key)
+    merged: List[Dict[str, Any]] = []
+    for idx, fact in enumerate(combined):
+        key = keys[idx]
+        if last_index[key] != idx:
+            continue
+        merged.append(fact)
+        if len(merged) >= settings.retriever_fact_cap:
+            break
+    return merged
+
+
+def _build_meta(
+    *,
+    intent: str,
+    intent_info: Dict[str, Any],
+    latencies: Dict[str, int],
+    plan: Optional[Dict[str, Any]],
+    context_note: str,
+    oracle_result,
+    hop_count: int,
+    sources_count: int,
+    k: int,
+    extra_result=None,
+    final_facts: Optional[List[Dict[str, Any]]] = None,
+) -> Dict[str, Any]:
+    meta: Dict[str, Any] = {
+        "intent": intent,
+        "latency_ms": latencies.get("total_ms", 0),
+        "latency_breakdown": latencies,
+        "gemini_first": True,
+        "gemini": {"intent": intent_info},
+        "retriever": {
+            "context_note": context_note,
+            "candidates": oracle_result.candidates,
+            "deduped": oracle_result.deduped,
+            "facts_returned": len(final_facts or []),
+            "latency_ms": oracle_result.latency_ms,
+        },
+        "hop_count": hop_count,
+        "show_debug_block": settings.show_debug_block,
+        "k": k,
+    }
+
+    if plan is not None:
+        meta["plan"] = plan
+
+    if extra_result is not None:
+        meta["retriever"]["hop2"] = {
+            "context_note": extra_result.context_note,
+            "candidates": extra_result.candidates,
+            "deduped": extra_result.deduped,
+            "latency_ms": extra_result.latency_ms,
+        }
+
+    if settings.show_debug_block:
+        meta["debug"] = {
+            "facts": final_facts or oracle_result.facts,
+            "raw_retriever_facts": oracle_result.raw_facts,
+            "plan_raw": (plan or {}).get("raw") if isinstance(plan, dict) else None,
+        }
+
+    observer.record(
+        {
+            "event": "ask2",
+            "intent": intent,
+            "question": intent_info.get("question") if isinstance(intent_info, dict) else None,
+            "filters_applied": (plan or {}).get("filters") if isinstance(plan, dict) else {},
+            "K_in": (plan or {}).get("k") if isinstance(plan, dict) else settings.oracle_knn_k,
+            "K_after_dedup": len(oracle_result.facts),
+            "rerank": "gemini",
+            "final_sources_count": sources_count,
+            "latency_ms": latencies.get("total_ms", 0),
+            "latency_breakdown": latencies,
+            "gemini": "answer" if sources_count else "plan",
+            "hop_count": hop_count,
+        },
+    )
+
+    return meta
+
+
+def _record_smalltalk(question: str, intent_info: Dict[str, Any], latencies: Dict[str, int]) -> None:
+    total_ms = latencies.get("total_ms", 0)
+    observer.record(
+        {
+            "event": "ask2",
+            "intent": "SMALL_TALK",
+            "question": question,
+            "filters_applied": {},
+            "K_in": 0,
+            "K_after_dedup": 0,
+            "rerank": "gemini",
+            "final_sources_count": 0,
+            "latency_ms": total_ms,
+            "latency_breakdown": latencies,
+            "gemini": "smalltalk",
+            "hop_count": 0,
+        }
+    )
+
+
+def run_pipeline(
+    question: str,
+    *,
+    k: int,
+    client_ip: Optional[str] = None,
+) -> Dict[str, Any]:
+    """Execute the Gemini-first orchestration and return the response payload."""
+
+    sanitized_q = (question or "").strip()
+    ip = (client_ip or "unknown").strip() or "unknown"
+
+    if not settings.gemini_first_enabled:
+        raise GeminiUnavailableError("gemini_first_disabled")
+
+    if not sanitized_q:
+        return {
+            "answer": "Please share a SustainaCore question so I can help.",
+            "sources": [],
+            "meta": {"intent": "EMPTY", "k": k, "show_debug_block": settings.show_debug_block},
+        }
+
+    try:
+        _enforce_rate_limit(ip)
+    except RateLimitError as exc:
+        observer.record(
+            {
+                "event": "rate_limited",
+                "ip": ip,
+                "intent": "UNKNOWN",
+                "question": sanitized_q,
+                "final_sources_count": 0,
+                "gemini": "none",
+            }
+        )
+        raise exc
+
+    latencies: Dict[str, int] = {}
+    t0 = time.time()
+
+    intent_start = time.time()
+    intent_info = gateway.classify_intent(sanitized_q)
+    latencies["intent_ms"] = int((time.time() - intent_start) * 1000)
+    intent = intent_info.get("intent", "INFO_REQUEST")
+
+    if intent == "SMALL_TALK":
+        small_start = time.time()
+        reply = gateway.compose_small_talk(sanitized_q)
+        latencies["gemini_smalltalk_ms"] = int((time.time() - small_start) * 1000)
+        total_ms = int((time.time() - t0) * 1000)
+        latencies["total_ms"] = total_ms
+        _record_smalltalk(sanitized_q, intent_info, latencies)
+        return {
+            "answer": reply,
+            "sources": [],
+            "meta": {
+                "intent": intent,
+                "latency_ms": total_ms,
+                "latency_breakdown": latencies,
+                "gemini_first": True,
+                "gemini": {"intent": intent_info},
+                "hop_count": 0,
+                "show_debug_block": settings.show_debug_block,
+                "k": k,
+            },
+        }
+
+    plan_start = time.time()
+    plan = gateway.plan_retrieval(sanitized_q)
+    latencies["plan_ms"] = int((time.time() - plan_start) * 1000)
+    plan_k = int(plan.get("k") or settings.oracle_knn_k)
+    filters = plan.get("filters") or {}
+    variants = plan.get("query_variants") or [sanitized_q]
+
+    retrieval_start = time.time()
+    oracle_result = retriever.retrieve(filters, variants, plan_k, hop_count=1)
+    latencies["oracle_ms"] = oracle_result.latency_ms
+    facts = oracle_result.facts
+    context_note = oracle_result.context_note
+    hop_count = 1
+
+    extra_result = None
+    if settings.allow_hop2 and plan.get("hop2") and len(facts) < settings.retriever_fact_cap:
+        hop_plan = plan["hop2"]
+        hop_variants = hop_plan.get("query_variants") or []
+        hop_filters = hop_plan.get("filters") or {}
+        if hop_variants:
+            extra_result = retriever.retrieve(hop_filters, hop_variants, plan_k, hop_count=2)
+            latencies["oracle_hop2_ms"] = extra_result.latency_ms
+            facts = _merge_facts(facts, extra_result.facts)
+            hop_count = 2
+            context_note = context_note + "\n-- hop2 --\n" + extra_result.context_note
+
+    retrieval_elapsed = int((time.time() - retrieval_start) * 1000)
+    latencies["oracle_total_ms"] = retrieval_elapsed
+
+    final_facts = facts[: settings.retriever_fact_cap]
+    retriever_payload = {
+        "facts": final_facts,
+        "context_note": context_note,
+    }
+
+    compose_start = time.time()
+    composed = gateway.compose_answer(sanitized_q, retriever_payload, plan, hop_count)
+    latencies["gemini_compose_ms"] = int((time.time() - compose_start) * 1000)
+
+    answer_text = composed.get("answer", "").strip()
+    sources_list = composed.get("sources") or []
+    total_ms = int((time.time() - t0) * 1000)
+    latencies["total_ms"] = total_ms
+
+    if not answer_text:
+        answer_text = "I’m sorry, I couldn’t generate an answer from the retrieved facts."
+
+    if not isinstance(sources_list, list):
+        sources_list = []
+
+    meta = _build_meta(
+        intent=intent,
+        intent_info={**intent_info, "question": sanitized_q},
+        latencies=latencies,
+        plan=plan,
+        context_note=context_note,
+        oracle_result=oracle_result,
+        hop_count=hop_count,
+        sources_count=len(sources_list),
+        k=k,
+        extra_result=extra_result,
+        final_facts=final_facts,
+    )
+    meta.setdefault("plan", plan)
+    meta["gemini"]["compose"] = composed.get("raw")
+
+    return {"answer": answer_text, "sources": sources_list[: settings.retriever_fact_cap], "meta": meta}
+
+
+__all__ = [
+    "GeminiUnavailableError",
+    "RateLimitError",
+    "run_pipeline",
+]
+

--- a/app/retrieval/settings.py
+++ b/app/retrieval/settings.py
@@ -1,0 +1,86 @@
+"""Runtime configuration for the Gemini-first orchestration."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+import os
+from typing import Literal
+
+
+def _env_bool(name: str, default: bool) -> bool:
+    value = os.environ.get(name)
+    if value is None:
+        return default
+    return value.strip().lower() in {"1", "true", "yes", "on"}
+
+
+def _env_int(name: str, default: int) -> int:
+    value = os.environ.get(name)
+    if value is None:
+        return default
+    try:
+        return int(value)
+    except (TypeError, ValueError):  # pragma: no cover - defensive
+        return default
+
+
+def _env_float(name: str, default: float) -> float:
+    value = os.environ.get(name)
+    if value is None:
+        return default
+    try:
+        return float(value)
+    except (TypeError, ValueError):  # pragma: no cover - defensive
+        return default
+
+
+@dataclass(slots=True)
+class Settings:
+    """Centralised configuration derived from the environment."""
+
+    gemini_first_enabled: bool = field(default_factory=lambda: _env_bool("GEMINI_FIRST_ENABLED", True))
+    show_debug_block: bool = field(default_factory=lambda: _env_bool("SHOW_DEBUG_BLOCK", False))
+    allow_hop2: bool = field(default_factory=lambda: _env_bool("ALLOW_HOP2", True))
+
+    gemini_bin: str = field(default_factory=lambda: os.environ.get("GEMINI_BIN", "gemini"))
+    gemini_model_intent: str = field(default_factory=lambda: os.environ.get("GEMINI_INTENT_MODEL", os.environ.get("GEMINI_MODEL", "gemini-1.5-pro")))
+    gemini_model_plan: str = field(default_factory=lambda: os.environ.get("GEMINI_PLAN_MODEL", os.environ.get("GEMINI_MODEL", "gemini-1.5-pro")))
+    gemini_model_answer: str = field(default_factory=lambda: os.environ.get("GEMINI_ANSWER_MODEL", os.environ.get("GEMINI_MODEL", "gemini-1.5-pro")))
+    gemini_timeout: float = field(default_factory=lambda: _env_float("GEMINI_TIMEOUT", _env_float("RAG_GEMINI_TIMEOUT", 8.0)))
+
+    oracle_table: str = field(default_factory=lambda: os.environ.get("ORACLE_VECTOR_TABLE", "ESG_DOCS"))
+    oracle_embedding_column: str = field(default_factory=lambda: os.environ.get("ORACLE_VECTOR_COLUMN", "EMBEDDING"))
+    oracle_text_column: str = field(default_factory=lambda: os.environ.get("ORACLE_TEXT_COLUMN", "CHUNK_TEXT"))
+    oracle_url_column: str = field(default_factory=lambda: os.environ.get("ORACLE_URL_COLUMN", "SOURCE_URL"))
+    oracle_normalized_url_column: str = field(default_factory=lambda: os.environ.get("ORACLE_NORM_URL_COLUMN", "NORMALIZED_URL"))
+    oracle_title_column: str = field(default_factory=lambda: os.environ.get("ORACLE_TITLE_COLUMN", "TITLE"))
+    oracle_source_column: str = field(default_factory=lambda: os.environ.get("ORACLE_SOURCE_COLUMN", "SOURCE_NAME"))
+    oracle_date_column: str = field(default_factory=lambda: os.environ.get("ORACLE_DATE_COLUMN", "PUBLISHED_DATE"))
+    oracle_doc_id_column: str = field(default_factory=lambda: os.environ.get("ORACLE_DOC_ID_COLUMN", "DOC_ID"))
+    oracle_source_id_column: str = field(default_factory=lambda: os.environ.get("ORACLE_SOURCE_ID_COLUMN", "SOURCE_ID"))
+    oracle_chunk_ix_column: str = field(default_factory=lambda: os.environ.get("ORACLE_CHUNK_INDEX_COLUMN", "CHUNK_IX"))
+    oracle_scope_filters: tuple[str, ...] = field(default_factory=lambda: tuple(f.strip().upper() for f in os.environ.get("ORACLE_ALLOWED_FILTERS", "SOURCE_TYPE,TICKER,DATE_FROM,DATE_TO,DOC_ID,SOURCE_ID").split(",") if f.strip()))
+
+    oracle_embed_model: str = field(default_factory=lambda: os.environ.get("ORACLE_EMBED_MODEL", "AI$MINILM_L6_V2"))
+    oracle_embed_proc: str = field(default_factory=lambda: os.environ.get("ORACLE_EMBED_PROC", "AI_VECTOR.EMBED_TEXT"))
+    oracle_embed_sql: str = field(
+        default_factory=lambda: os.environ.get(
+            "ORACLE_EMBED_SQL",
+            "SELECT AI_VECTOR.EMBED_TEXT(:model, :text) FROM DUAL",
+        )
+    )
+    oracle_knn_metric: Literal["COSINE", "DOT"] = field(default_factory=lambda: os.environ.get("ORACLE_KNN_METRIC", "COSINE").upper() == "DOT" and "DOT" or "COSINE")
+    oracle_knn_k: int = field(default_factory=lambda: _env_int("ORACLE_KNN_K", 24))
+
+    retriever_max_facts: int = field(default_factory=lambda: _env_int("RETRIEVER_MAX_FACTS", 8))
+    retriever_fact_cap: int = field(default_factory=lambda: _env_int("RETRIEVER_FACT_CAP", 6))
+    retriever_per_source_cap: int = field(default_factory=lambda: _env_int("RETRIEVER_PER_SOURCE_CAP", 2))
+
+    rate_limit_window_seconds: int = field(default_factory=lambda: _env_int("ASK2_RATE_WINDOW", 10))
+    rate_limit_max_requests: int = field(default_factory=lambda: _env_int("ASK2_RATE_MAX", 8))
+
+    latency_budget_ms: int = field(default_factory=lambda: _env_int("ASK2_LATENCY_BUDGET_MS", 4500))
+
+
+settings = Settings()
+

--- a/config/env.sample
+++ b/config/env.sample
@@ -1,0 +1,31 @@
+# Gemini-first orchestration
+GEMINI_API_KEY=replace-with-your-key
+GEMINI_BIN=gemini
+GEMINI_MODEL=gemini-1.5-pro
+GEMINI_TIMEOUT=8
+
+# Feature flags
+GEMINI_FIRST_ENABLED=1
+SHOW_DEBUG_BLOCK=0
+ALLOW_HOP2=1
+
+# Rate limiting (8 requests per 10 seconds per IP)
+ASK2_RATE_WINDOW=10
+ASK2_RATE_MAX=8
+
+# Oracle Autonomous Database credentials
+DB_USER=WKSP_ESGAPEX
+DB_PASSWORD=replace-me
+DB_DSN=dbri4x6_high
+TNS_ADMIN=/opt/adb_wallet
+WALLET_PWD=replace-me
+
+# Oracle embedding configuration
+ORACLE_EMBED_MODEL=AI$MINILM_L6_V2
+ORACLE_EMBED_SQL=SELECT AI_VECTOR.EMBED_TEXT(:model, :text) FROM DUAL
+
+# Retriever caps
+RETRIEVER_MAX_FACTS=8
+RETRIEVER_FACT_CAP=6
+RETRIEVER_PER_SOURCE_CAP=2
+

--- a/tests/test_ask2_contract.py
+++ b/tests/test_ask2_contract.py
@@ -23,6 +23,10 @@ def test_ask2_contract_keys():
     payload = response.json()
     for key in ("answer", "sources", "meta"):
         assert key in payload
+    assert isinstance(payload["sources"], list)
+    assert "intent" in payload["meta"]
+    assert "latency_ms" in payload["meta"]
+    assert "show_debug_block" in payload["meta"]
 
 
 def test_ask2_non_empty_answer():
@@ -30,3 +34,4 @@ def test_ask2_non_empty_answer():
     payload = response.json()
     assert len(payload["answer"]) > 0
     assert payload["answer"].strip()
+    assert isinstance(payload["meta"].get("retriever", {}), dict)

--- a/tests/test_gemini_gateway_utils.py
+++ b/tests/test_gemini_gateway_utils.py
@@ -1,0 +1,155 @@
+from importlib import util
+from pathlib import Path
+import sys
+import types
+
+_repo_root = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(_repo_root))
+
+
+def _load_module():
+    names = ["app", "app.rag", "app.rag.gemini_cli"]
+    original = {name: sys.modules.get(name) for name in names}
+    try:
+        app_pkg = types.ModuleType("app")
+        app_pkg.__path__ = [str(_repo_root / "app")]
+        sys.modules["app"] = app_pkg
+
+        rag_pkg = types.ModuleType("app.rag")
+        rag_pkg.__path__ = [str(_repo_root / "app" / "rag")]
+        sys.modules["app.rag"] = rag_pkg
+
+        gemini_cli_spec = util.spec_from_file_location(
+            "app.rag.gemini_cli", _repo_root / "app" / "rag" / "gemini_cli.py"
+        )
+        assert gemini_cli_spec and gemini_cli_spec.loader
+        gemini_cli_module = util.module_from_spec(gemini_cli_spec)
+        sys.modules["app.rag.gemini_cli"] = gemini_cli_module
+        gemini_cli_spec.loader.exec_module(gemini_cli_module)
+
+        module_path = _repo_root / "app" / "retrieval" / "gemini_gateway.py"
+        spec = util.spec_from_file_location("app.retrieval.gemini_gateway", module_path)
+        assert spec and spec.loader
+        module = util.module_from_spec(spec)
+        sys.modules["app.retrieval.gemini_gateway"] = module
+        spec.loader.exec_module(module)
+        return module
+    finally:
+        for name, saved in original.items():
+            if saved is None:
+                sys.modules.pop(name, None)
+            else:
+                sys.modules[name] = saved
+
+
+_module = _load_module()
+_clean_answer_text = getattr(_module, "_clean_answer_text")
+_dedup_sources = getattr(_module, "_dedup_sources")
+_build_sources_from_facts = getattr(_module, "_build_sources_from_facts")
+
+
+def test_clean_answer_text_removes_debug_blocks():
+    raw = """Here’s the best supported answer from the retrieved sources.
+
+Why this answer:
+- Source 1: Something
+
+Main insight with detail [CITE_ID].
+
+Sources:
+- Source 1
+- Source 2
+"""
+
+    cleaned = _clean_answer_text(raw)
+
+    assert "Here’s the best supported answer" not in cleaned
+    assert "Why this answer" not in cleaned
+    assert cleaned.startswith("Main insight")
+
+
+def test_clean_answer_text_preserves_content():
+    raw = "Insightful line [FCA].\n\nSecond line."  # no debug
+    cleaned = _clean_answer_text(raw)
+
+    assert cleaned == raw
+
+
+def test_clean_answer_text_returns_empty_when_only_debug_sections():
+    raw = "\n".join(
+        [
+            "Here’s the best supported answer from the retrieved sources.",
+            "Why this answer:",
+            "- Source 1: Detail",
+            "Sources:",
+            "- Source 1",
+            "- Source 2",
+        ]
+    )
+
+    cleaned = _clean_answer_text(raw)
+
+    assert cleaned == ""
+
+
+def test_dedup_sources_keeps_last_occurrence():
+    sources = [
+        "First Title — Publisher (2024)",
+        "Duplicate — Org",  # should be dropped in favour of the later entry
+        "Second Title — Publisher (2023)",
+        "duplicate — org",  # same as above but later and lower case
+    ]
+
+    deduped = _dedup_sources(sources, limit=10)
+
+    assert "First Title — Publisher (2024)" in deduped
+    assert "Second Title — Publisher (2023)" in deduped
+    assert "duplicate — org" in deduped
+    assert "Duplicate — Org" not in deduped
+    assert deduped.index("duplicate — org") > deduped.index("Second Title — Publisher (2023)")
+
+
+def test_build_sources_from_facts_prefers_cited_and_latest_entries():
+    answer = "The TECH100 tracks AI leaders [TECH100_METHOD]. Microsoft remains a member [MSFT_PROFILE]."
+    facts = [
+        {
+            "citation_id": "MSFT_PROFILE",
+            "title": "Microsoft Corporation",
+            "source_name": "TECH100",
+            "date": "2024-03-01",
+            "url": "https://example.com/microsoft?utm_source=newsletter",
+        },
+        {
+            "citation_id": "TECH100_METHOD",
+            "title": "TECH100 Methodology",
+            "source_name": "SustainaCore",
+            "date": "2024-01-15",
+            "url": "https://example.com/methodology",
+        },
+        {
+            "citation_id": "MSFT_PROFILE",
+            "title": "Microsoft Corporation (Updated)",
+            "source_name": "SustainaCore",
+            "date": "2024-04-01",
+            "url": "https://example.com/microsoft",
+        },
+    ]
+
+    sources = _build_sources_from_facts(answer, facts, limit=6)
+
+    assert sources[0] == "TECH100 Methodology — SustainaCore (2024-01-15)"
+    assert sources[1] == "Microsoft Corporation (Updated) — SustainaCore (2024-04-01)"
+    assert len(sources) == 2
+
+
+def test_build_sources_from_facts_falls_back_to_uncited_facts():
+    answer = "No citations in this answer."
+    facts = [
+        {"citation_id": "FACT_A", "title": "Fact A", "source_name": "Org", "date": "2024", "url": "https://a"},
+        {"citation_id": "FACT_B", "title": "Fact B", "source_name": "Org", "date": "2023", "url": "https://b"},
+    ]
+
+    sources = _build_sources_from_facts(answer, facts, limit=3)
+
+    assert sources == ["Fact A — Org (2024)", "Fact B — Org (2023)"]
+


### PR DESCRIPTION
## Summary
- harden Gemini answer cleaning so debug headers and numbered source bullets are always stripped, yielding an empty string when only scaffolding remains
- deduplicate the composed source list against the six-item cap even when Gemini omits inline citations
- add regression coverage for the debug-only answer path to guard the sanitisation logic

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68d3df8175c48328bcd2b163fb88ef23