### PR TITLE
Fix missing logging import in ask2 facade

### DIFF
--- a/tests/test_app_imports.py
+++ b/tests/test_app_imports.py
@@ -1,0 +1,25 @@
+"""Regression tests for importing the legacy Flask facade."""
+
+import importlib
+import sys
+
+
+def test_app_module_imports_cleanly(monkeypatch):
+    """Ensure importing ``app`` doesn't raise and wires the ask2 router."""
+
+    # Drop any cached module so we exercise the top-level imports each time.
+    monkeypatch.syspath_prepend("/workspace/Sustainacore")
+    sys.modules.pop("app", None)
+
+    module = importlib.import_module("app")
+
+    # The module should expose the Flask ``app`` and the legacy router helper.
+    assert hasattr(module, "app")
+    assert hasattr(module, "_call_route_ask2_facade")
+
+    route = getattr(module, "_route_ask2", None)
+    assert callable(route), "legacy ask2 router should be available"
+
+    shaped, status = module._call_route_ask2_facade("hi", 2)
+    assert status == 200
+    assert shaped["meta"]["routing"] == "smalltalk"


### PR DESCRIPTION
## Summary
- add the missing logging import so the Flask entrypoint no longer raises at import time
- add a regression test that verifies the legacy `app` module imports successfully and exposes the expected helpers

## Testing
- pytest tests/test_app_imports.py tests/test_rag_routing.py -q

------
https://chatgpt.com/codex/tasks/task_e_68d50a6e906c8328ac63b1012298ec41