### PR TITLE
v28

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -29,17 +29,48 @@ jobs:
           cd /opt/sustainacore-ai
           git fetch --all
           git reset --hard origin/main
+          python3 -m venv .venv
+          source .venv/bin/activate
+          python -m pip install --upgrade pip
+          python -m pip install -r requirements.txt
+          python - <<'PY'
+import importlib, sys
+missing = []
+for module in ("fastapi", "uvicorn"):
+    try:
+        importlib.import_module(module)
+    except Exception as exc:  # pragma: no cover - deployment guardrail
+        missing.append(f"{module}: {exc}")
+if missing:
+    print("::error::Failed to import dependencies::" + "; ".join(missing))
+    sys.exit(1)
+PY
           sudo systemctl daemon-reload || true
           sudo systemctl restart sustainacore-ai.service
+          if ! sudo systemctl is-active --quiet sustainacore-ai.service; then
+            echo '::error::sustainacore-ai.service failed to start'
+            exit 1
+          fi
+          curl --fail --retry 8 --retry-delay 5 --retry-connrefused "http://127.0.0.1:8080/healthz"
+          curl --fail --retry 8 --retry-delay 5 --retry-connrefused -s -X POST "http://127.0.0.1:8080/ask" \
+            -H 'Content-Type: application/json' --data '{"question":"ping","top_k":1}' \
+            | python3 - <<'PY'
+import json, sys
+try:
+    payload = json.load(sys.stdin)
+except Exception as exc:  # pragma: no cover - deployment guardrail
+    print(f"::error::Failed to parse /ask response: {exc}")
+    sys.exit(1)
+answer = str(payload.get("answer") or "").strip()
+if not answer:
+    print("::error::/ask returned an empty answer")
+    sys.exit(1)
+PY
           REMOTE
 
       - name: Verify health
         run: |
           curl --fail --retry 12 --retry-delay 5 --retry-connrefused "http://${VM_HOST}:8080/healthz"
-
-      - name: Verify metrics
-        run: |
-          curl --fail --retry 12 --retry-delay 5 --retry-connrefused "http://${VM_HOST}:8080/metrics"
 
       - name: Verify metrics
         run: |

--- a/app/retrieval/app.py
+++ b/app/retrieval/app.py
@@ -1,7 +1,6 @@
-from __future__ import annotations
-from fastapi import FastAPI, Query
-from typing import Any, Dict
-import time
+from typing import Any, Dict, List, Optional, Set, Tuple
+
+from fastapi import Body, FastAPI, HTTPException, Query
 
 # Router is optional; app must still boot if it’s missing or broken.
 try:
@@ -9,23 +8,183 @@ try:
 except Exception:
     _route_ask2 = None
 
-def _sanitize_k(value: Any, default: int = 4) -> int:
-    try:
-        k = int(value)
-    except Exception:
-        k = default
-    return max(1, min(10, k))
+try:
+    from app.retrieval.service import (
+        GeminiUnavailableError,
+        RateLimitError,
+        run_pipeline,
+    )
+except Exception:  # pragma: no cover - fall back to facade-only mode
+    run_pipeline = None
+
+    class RateLimitError(Exception):
+        """Placeholder when the service layer failed to import."""
+
+    class GeminiUnavailableError(Exception):
+        """Placeholder when the service layer failed to import."""
 
 FALLBACK = (
     "I couldn’t find a grounded answer in the indexed docs yet. "
     "Try adding a company/topic (e.g., Microsoft, TECH100) or a specific field."
 )
 
+ASK_EMPTY = "Please provide a question so I can help."  # Friendly guardrail
+
+
+def _sanitize_k(value: Any, default: int = 4) -> int:
+    try:
+        k = int(value)
+    except Exception:
+        k = default
+    if k < 1:
+        k = 1
+    if k > 10:
+        k = 10
+    return k
+
+
+def _shape_sources(raw_sources: Any) -> Tuple[List[str], List[Dict[str, Any]]]:
+    urls: List[str] = []
+    contexts: List[Dict[str, Any]] = []
+    seen: Set[str] = set()
+    if not isinstance(raw_sources, list):
+        return urls, contexts
+    for item in raw_sources:
+        url: Optional[str] = None
+        title: Optional[str] = None
+        if isinstance(item, dict):
+            title_candidate = item.get("title") or item.get("source_title") or item.get("name")
+            if isinstance(title_candidate, str):
+                stripped_title = title_candidate.strip()
+                title = stripped_title or None
+            url_candidate = (
+                item.get("url")
+                or item.get("source_url")
+                or item.get("link")
+                or item.get("href")
+            )
+            if isinstance(url_candidate, str):
+                url_candidate = url_candidate.strip()
+                url = url_candidate or None
+        elif isinstance(item, str):
+            stripped = item.strip()
+            if stripped:
+                url = stripped
+        if not url or url in seen:
+            continue
+        seen.add(url)
+        urls.append(url)
+        context: Dict[str, Any] = {"source_url": url}
+        if title is not None:
+            context["title"] = title
+        contexts.append(context)
+    return urls, contexts
+
+
+def _build_payload(
+    *,
+    answer: str,
+    raw_sources: Any,
+    top_k: int,
+    note: str,
+    meta: Optional[Dict[str, Any]] = None,
+    limit_sources: Optional[int] = None,
+) -> Dict[str, Any]:
+    sources, contexts = _shape_sources(raw_sources)
+    if limit_sources is not None:
+        sources = sources[:limit_sources]
+        contexts = contexts[:limit_sources]
+    payload_meta: Dict[str, Any] = {}
+    if isinstance(meta, dict):
+        payload_meta.update(meta)
+    payload_meta["provider"] = payload_meta.get("provider") or "oracle"
+    payload_meta["note"] = note
+    payload_meta["k"] = top_k
+    return {
+        "answer": answer,
+        "contexts": contexts,
+        "sources": sources,
+        "meta": payload_meta,
+    }
+
 app = FastAPI(title="SustainaCore Retrieval Facade", version="1.0")
 
 @app.get("/healthz")
 def healthz():
-    return {"status": "ok", "ts": time.time()}
+    return {"ok": True}
+
+
+@app.post("/ask")
+def ask(payload: Dict[str, Any] = Body(default_factory=dict)) -> Dict[str, Any]:
+    question = (
+        payload.get("question")
+        or payload.get("q")
+        or payload.get("text")
+        or ""
+    )
+    top_k = _sanitize_k(payload.get("top_k") or payload.get("k") or payload.get("limit"))
+    question_text = question.strip() if isinstance(question, str) else ""
+
+    if not question_text:
+        return _build_payload(
+            answer=ASK_EMPTY,
+            raw_sources=[],
+            top_k=top_k,
+            note="fallback",
+            meta={"reason": "empty_question"},
+        )
+
+    if run_pipeline is None:
+        return _build_payload(
+            answer=FALLBACK,
+            raw_sources=[],
+            top_k=top_k,
+            note="fallback",
+            meta={"reason": "pipeline_unavailable"},
+        )
+
+    try:
+        result = run_pipeline(question_text, k=top_k)
+    except RateLimitError as exc:
+        raise HTTPException(status_code=429, detail=str(exc))
+    except GeminiUnavailableError:
+        return _build_payload(
+            answer=FALLBACK,
+            raw_sources=[],
+            top_k=top_k,
+            note="fallback",
+            meta={"reason": "gemini_unavailable"},
+        )
+    except Exception:
+        return _build_payload(
+            answer=FALLBACK,
+            raw_sources=[],
+            top_k=top_k,
+            note="fallback",
+            meta={"reason": "pipeline_error"},
+        )
+
+    answer_text = str(result.get("answer") or "").strip()
+    raw_sources = result.get("sources") or []
+    meta = result.get("meta") if isinstance(result.get("meta"), dict) else {}
+
+    if not answer_text:
+        return _build_payload(
+            answer=FALLBACK,
+            raw_sources=raw_sources,
+            top_k=top_k,
+            note="fallback",
+            meta={**meta, "reason": "empty_answer"},
+            limit_sources=3,
+        )
+
+    return _build_payload(
+        answer=answer_text,
+        raw_sources=raw_sources,
+        top_k=top_k,
+        note="ok",
+        meta=meta,
+    )
 
 @app.get("/ask2")
 def ask2(q: str = Query("", alias="q"), k: int = Query(4, alias="k")) -> Dict[str, Any]:

--- a/ops/systemd/sustainacore-ai.service
+++ b/ops/systemd/sustainacore-ai.service
@@ -1,0 +1,16 @@
+[Unit]
+Description=SustainaCore Retrieval API
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+WorkingDirectory=/opt/sustainacore-ai
+Environment=TNS_ADMIN=/opt/adb_wallet
+Environment=XDG_CACHE_HOME=/opt/fastembed
+ExecStart=/opt/sustainacore-ai/.venv/bin/uvicorn app.retrieval.app:app --host 127.0.0.1 --port 8080 --workers 1
+Restart=on-failure
+RestartSec=5
+
+[Install]
+WantedBy=multi-user.target

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,10 @@
 flask==3.0.2
 gunicorn==21.2.0
 requests==2.32.3
-oracledb>=3.2.0
-fastapi>=0.111,<1.0
-uvicorn>=0.30,<0.31
-httpx>=0.27,<0.28
+oracledb==2.4.*
+fastapi==0.110.*
+uvicorn[standard]==0.30.*
+httpx==0.27.*
+numpy==1.26.*
+fastembed==0.3.*
+faiss-cpu==1.8.*

--- a/tests/test_contract.py
+++ b/tests/test_contract.py
@@ -19,4 +19,4 @@ def test_healthz():
     client = TestClient(mod.app)
     r = client.get("/healthz")
     assert r.status_code == 200
-    assert r.json().get("status") == "ok"
+    assert r.json() == {"ok": True}

--- a/tests/test_health_and_contract.py
+++ b/tests/test_health_and_contract.py
@@ -18,6 +18,16 @@ if p.exists():
         assert r.status_code == 200
         assert r.json() == {"ok": True}
 
+    def test_ask_contract():
+        r = client.post("/ask", json={"question": "ping", "top_k": 1})
+        assert r.status_code == 200
+        payload = r.json()
+        assert "answer" in payload and isinstance(payload["answer"], str)
+        assert payload["answer"].strip() != ""
+        assert isinstance(payload.get("contexts"), list)
+        assert isinstance(payload.get("sources"), list)
+        assert isinstance(payload.get("meta"), dict)
+
     def test_ask2_contract():
         r = client.get("/ask2", params={"q":"test","k":1})
         j = r.json()


### PR DESCRIPTION
## Summary
- implement FastAPI /ask endpoint that returns answer/context/source/meta contract and ensures healthy fallbacks.
- simplify the legacy WSGI facade now that the route enforces non-empty answers.
- pin deployment dependencies, add uvicorn systemd unit, and harden the GitHub Actions deploy workflow with venv recreation and contract checks.

## Testing
- python -m pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68d51ea21af0832894e3b1a4f0501cdf