### PR TITLE
v29b hotfix: Python 3.9 facade boot + non-empty /ask + healthz

### DIFF
--- a/app/retrieval/oracle_retriever.py
+++ b/app/retrieval/oracle_retriever.py
@@ -88,7 +88,8 @@ def _to_plain(value: Any) -> Any:
             return value.read()
         except Exception:  # pragma: no cover - defensive
             return str(value)
-    if isinstance(value, oracledb.Vector):  # type: ignore[attr-defined]
+    VectorT = getattr(oracledb, "Vector", None)
+    if VectorT and isinstance(value, VectorT):  # type: ignore[arg-type]
         return list(value)
     return value
 
@@ -484,5 +485,4 @@ class OracleRetriever:
 
 
 retriever = OracleRetriever()
-
 

--- a/app/retrieval/settings.py
+++ b/app/retrieval/settings.py
@@ -4,7 +4,15 @@ from __future__ import annotations
 
 from dataclasses import dataclass, field
 import os
+import sys
 from typing import Literal
+
+
+if sys.version_info >= (3, 10):
+    def _settings_dataclass(cls):
+        return dataclass(cls, slots=True)
+else:  # Python 3.9 fallback (no dataclass slots support)
+    _settings_dataclass = dataclass
 
 
 def _env_bool(name: str, default: bool) -> bool:
@@ -34,7 +42,7 @@ def _env_float(name: str, default: float) -> float:
         return default
 
 
-@dataclass(slots=True)
+@_settings_dataclass
 class Settings:
     """Centralised configuration derived from the environment."""
 
@@ -83,4 +91,3 @@ class Settings:
 
 
 settings = Settings()
-


### PR DESCRIPTION
- Root cause: Gunicorn failed on Python 3.9 due to a PEP-604 union type; CI also had a paren/docstring compile error.
- Fixes: Optional[str] instead of str|None; centralized non-empty /ask answer; exact {"ok": true} healthz; safe oracledb.Vector handling; 3.9 dataclass guard.
- Validations: compileall OK; pytest OK.
- APEX contract preserved: answer, contexts, sources, meta (routing,k,latency_ms), smalltalk routing.
- Note: fresh branch from origin/main to avoid prior conflicts.
