### PR TITLE
feat: harden ask2 routing and tests

### DIFF
--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -20,7 +20,15 @@
 - Requests can override scope via query or JSON parameters: `docset`, `namespace`, `ticker`, or `company`.
 - Set `RETRIEVAL_SCOPING=off` to temporarily disable scoping if wider searches are required.
 - `RETRIEVAL_TOP_K` controls the initial candidate pool (defaults to 8). Increase cautiously if additional recall is required.
-- `SIMILARITY_FLOOR` (default 0.58) prevents low-signal matches. If the best score falls below the floor the service returns the “insufficient context” message instead of forcing an answer.
+- `SIMILARITY_FLOOR` (default 0.58) defines the similarity threshold used for retrieval quality checks.
+- `SIMILARITY_FLOOR_MODE` controls how the floor is applied:
+  - `off` — bypass the check entirely.
+  - `monitor` *(default)* — log when the top-1 score falls below the floor but continue returning the retrieved answer and contexts.
+  - `enforce` — replace low-similarity answers with the standard insufficient-context message and omit `contexts`/sources to avoid citing weak evidence.
+
+## Small-talk handling
+- `/ask2` now short-circuits greetings and simple help messages (`hi`, `hello`, `hey`, `thanks`, `thank you`, `help`, `goodbye`).
+- These requests return a short professional acknowledgement and 2–4 suggested follow-up prompts without calling retrieval or emitting `contexts`.
 
 ## Observability
 - Embedding parity, readiness results, and multi-hit orchestrator fallbacks emit structured logs (`sustainacore.embed`, `app.readyz`, `app.multihit`).

--- a/retrieval/config.py
+++ b/retrieval/config.py
@@ -19,6 +19,9 @@ def _env_bool(name: str, default: bool = False) -> bool:
 
 RETRIEVAL_TOP_K = max(8, int(os.getenv("RETRIEVAL_TOP_K", os.getenv("FUSION_TOPK_BASE", "8"))))
 SIMILARITY_FLOOR = float(os.getenv("SIMILARITY_FLOOR", "0.58"))
+SIMILARITY_FLOOR_MODE = os.getenv("SIMILARITY_FLOOR_MODE", "monitor").strip().lower()
+if SIMILARITY_FLOOR_MODE not in {"off", "monitor", "enforce"}:
+    SIMILARITY_FLOOR_MODE = "monitor"
 RETRIEVAL_SCOPING_ENABLED = _env_bool("RETRIEVAL_SCOPING", True)
 INSUFFICIENT_CONTEXT_MESSAGE = (
     "I’m not confident I have enough Sustainacore context to answer that yet. "
@@ -30,6 +33,7 @@ def config_snapshot() -> Dict[str, object]:
     return {
         "retrieval_top_k": RETRIEVAL_TOP_K,
         "similarity_floor": SIMILARITY_FLOOR,
+        "similarity_floor_mode": SIMILARITY_FLOOR_MODE,
         "scoping_enabled": RETRIEVAL_SCOPING_ENABLED,
     }
 
@@ -37,6 +41,7 @@ def config_snapshot() -> Dict[str, object]:
 __all__ = [
     "RETRIEVAL_TOP_K",
     "SIMILARITY_FLOOR",
+    "SIMILARITY_FLOOR_MODE",
     "RETRIEVAL_SCOPING_ENABLED",
     "INSUFFICIENT_CONTEXT_MESSAGE",
     "config_snapshot",

--- a/tests/test_ask2_behaviors.py
+++ b/tests/test_ask2_behaviors.py
@@ -1,0 +1,136 @@
+import sys
+from pathlib import Path
+from typing import Dict, Tuple
+
+import pytest
+from flask import Response
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
+import app as ask_app
+
+
+@pytest.fixture(autouse=True)
+def disable_external_calls(monkeypatch):
+    monkeypatch.setattr(ask_app, "_gemini_run_pipeline", None)
+    monkeypatch.setattr(ask_app, "embed_text", lambda text, settings=None: [0.0])
+    monkeypatch.setattr(ask_app, "_top_k_by_vector", lambda *args, **kwargs: [])
+    monkeypatch.setattr(ask_app, "smalltalk_response", lambda _q: None)
+    return
+
+
+def _stub_route(monkeypatch, payload: Dict[str, object]):
+    def _inner(_question: str, _k: int) -> Dict[str, object]:
+        return payload
+
+    monkeypatch.setattr(ask_app, "_route_ask2", _inner)
+
+
+def _stub_route_raising(monkeypatch, exc: Exception):
+    def _inner(_question: str, _k: int):
+        raise exc
+
+    monkeypatch.setattr(ask_app, "_route_ask2", _inner)
+
+
+def _invoke_ask2(query: str, *, headers=None) -> Tuple[dict, int]:
+    headers = headers or {}
+    with ask_app.app.test_request_context("/ask2", method="GET", query_string={"q": query}, headers=headers):
+        response, status = ask_app.ask2()
+        assert isinstance(response, Response)
+        return response.get_json(), status
+
+
+def test_header_robustness(monkeypatch):
+    payload = {
+        "answer": "Header path answer",
+        "contexts": [{"title": "Doc", "snippet": "Snippet", "score": 0.9}],
+        "sources": [{"title": "Doc", "url": "http://example.com"}],
+    }
+    _stub_route(monkeypatch, payload)
+
+    body, status = _invoke_ask2("test question")
+    assert status == 200
+    assert body["answer"] == "Header path answer"
+    assert isinstance(body["contexts"], list)
+
+    body_with_headers, status_with_headers = _invoke_ask2(
+        "test question", headers={"X-Unexpected": "value", "X-Forwarded-For": "1.2.3.4"}
+    )
+    assert status_with_headers == 200
+    assert body_with_headers["answer"] == "Header path answer"
+
+
+def test_small_talk_short_circuit(monkeypatch):
+    _stub_route_raising(monkeypatch, RuntimeError("should not call legacy router"))
+
+    for phrase in ["hi", "hello!", "thanks", "help", "goodbye"]:
+        body, status = _invoke_ask2(phrase)
+        assert status == 200
+        assert "contexts" not in body
+        assert "Suggested follow-ups" in body["answer"]
+        suggestion_lines = [line for line in body["answer"].splitlines() if line.startswith("- ")]
+        assert 2 <= len(suggestion_lines) <= 4
+
+
+def test_sources_removed_from_answer(monkeypatch):
+    payload = {
+        "answer": "Result\nWhy this answer:\n- detail\nSources:\n- one",
+        "contexts": [{"title": "Doc", "score": 0.75}],
+        "sources": [{"title": "Doc", "url": "https://example.com"}],
+    }
+    _stub_route(monkeypatch, payload)
+
+    body, status = _invoke_ask2("tell me")
+    assert status == 200
+    assert "Why this answer" not in body["answer"]
+    assert "Sources:" not in body["answer"]
+    assert body["contexts"]
+    assert body["sources"]
+
+
+def test_similarity_floor_monitor_and_enforce(monkeypatch, caplog):
+    payload = {
+        "answer": "Low confidence answer",
+        "contexts": [{"title": "Doc", "score": 0.2}],
+        "sources": [{"title": "Doc", "url": "https://example.com"}],
+    }
+    _stub_route(monkeypatch, payload)
+
+    monkeypatch.setattr(ask_app, "SIMILARITY_FLOOR", 0.5)
+    monkeypatch.setattr(ask_app, "SIMILARITY_FLOOR_MODE", "monitor")
+
+    caplog.clear()
+    caplog.set_level("INFO", logger="app.ask2")
+    monitor_body, monitor_status = _invoke_ask2("monitor mode")
+    assert monitor_status == 200
+    assert monitor_body["contexts"]
+    assert any("floor_decision=below_floor" in record.message for record in caplog.records)
+
+    monkeypatch.setattr(ask_app, "SIMILARITY_FLOOR_MODE", "enforce")
+    caplog.clear()
+    enforce_body, enforce_status = _invoke_ask2("enforce mode")
+    assert enforce_status == 200
+    assert "contexts" not in enforce_body
+    assert enforce_body["sources"] == []
+    assert "not confident" in enforce_body["answer"].lower()
+    assert any("floor_decision=below_floor" in record.message for record in caplog.records)
+
+
+def test_contract_shape_remains(monkeypatch):
+    payload = {
+        "answer": "Shape answer",
+        "contexts": [{"title": "Doc", "score": 0.8}],
+        "sources": [{"title": "Doc", "url": "https://example.com"}],
+        "meta": {"show_debug_block": False},
+    }
+    _stub_route(monkeypatch, payload)
+
+    body, status = _invoke_ask2("shape")
+    assert status == 200
+    assert set(["answer", "sources", "meta"]).issubset(body.keys())
+    assert isinstance(body["sources"], list)
+    assert isinstance(body.get("contexts"), list)
+    assert isinstance(body["meta"], dict)


### PR DESCRIPTION
## Summary
- make /ask2 resilient to missing routing headers and strip inline source footers before returning answers
- add small-talk short circuiting, similarity floor enforcement modes, and logging for ask2 requests
- document the new environment flags and add regression tests that cover headers, small talk, sanitization, and similarity floor behaviour

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68d67fc7f6ec832893ab0555a91c31e7