### PR TITLE
Remove legacy /ask route in favor of /ask2

### DIFF
--- a/app/retrieval/app.py
+++ b/app/retrieval/app.py
@@ -149,8 +149,8 @@ def metrics() -> Dict[str, float]:
     return {"uptime": float(uptime)}
 
 
-@app.post("/ask")
-def ask(
+@app.post("/ask2")
+def ask2_post(
     request: Request,
     payload: Dict[str, Any] = Body(default_factory=dict),
 ) -> Dict[str, Any]:

--- a/nosuggest_mw.py
+++ b/nosuggest_mw.py
@@ -82,8 +82,7 @@ class NoSuggestMiddleware:
     def __call__(self,environ,start_response):
         path=environ.get('PATH_INFO',''); alias_info={}
         if path == '/ask2':
-            environ['PATH_INFO']='/ask'
-            alias_info={'X-NoSuggest-Path':'/ask2','X-NoSuggest-Rewrite':'/ask'}
+            alias_info={'X-NoSuggest-Path':'/ask2'}
         status_headers={}; body_chunks=[]
         def _cap_start(status,headers,exc_info=None):
             status_headers['status']=status; status_headers['headers']=headers[:]

--- a/orchestrator_mw.py
+++ b/orchestrator_mw.py
@@ -5,7 +5,7 @@
 # - Normalize noisy UI prompts.
 # - Light intent classification + entity extraction.
 # - Generate 3–5 query variants.
-# - Hit downstream /ask multiple times; fuse contexts via RRF; apply MMR diversity.
+# - Hit downstream /ask2 multiple times; fuse contexts via RRF; apply MMR diversity.
 # - Compose evidence-first answer scaffold (answer → bullets with [S1..] → source map).
 # - Bounded latency and chunk budgets; never touch systemd or NGINX.
 
@@ -188,7 +188,7 @@ class _Cap:
 def _mk_environ(body: bytes) -> dict:
     return {
         "REQUEST_METHOD": "POST",
-        "PATH_INFO": "/ask",
+        "PATH_INFO": "/ask2",
         "SERVER_NAME": "127.0.0.1",
         "SERVER_PORT": "8080",
         "wsgi.version": (1, 0),
@@ -216,8 +216,8 @@ class MultiHitMiddleware:
 
     def __call__(self, environ, start_response):
         t0 = _now_ms()
-        # only intercept POST /ask
-        if not (environ.get("PATH_INFO")=="/ask" and (environ.get("REQUEST_METHOD") or "").upper()=="POST"):
+        # only intercept POST /ask2
+        if not (environ.get("PATH_INFO")=="/ask2" and (environ.get("REQUEST_METHOD") or "").upper()=="POST"):
             return self.app(environ, start_response)
 
         # read body once

--- a/tests/test_health_and_contract.py
+++ b/tests/test_health_and_contract.py
@@ -18,18 +18,9 @@ if p.exists():
         assert r.status_code == 200
         assert r.json() == {"ok": True}
 
-    def test_ask_contract():
+    def test_ask_endpoint_removed():
         r = client.post("/ask", json={"question": "ping", "top_k": 1})
-        assert r.status_code == 200
-        payload = r.json()
-        assert "answer" in payload and isinstance(payload["answer"], str)
-        assert payload["answer"].strip() != ""
-        assert isinstance(payload.get("contexts"), list)
-        for ctx in payload["contexts"]:
-            assert isinstance(ctx, dict)
-            assert "source_url" in ctx
-        assert isinstance(payload.get("sources"), list)
-        assert isinstance(payload.get("meta"), dict)
+        assert r.status_code == 404
 
     def test_ask2_contract():
         r = client.get("/ask2", params={"q":"test","k":1})

--- a/wsgi_refine.py
+++ b/wsgi_refine.py
@@ -24,8 +24,8 @@ def app(environ, start_response):
     status  = sh.get("status", "200 OK")
     headers = sh.get("headers", [])
 
-    # Intercept only successful JSON responses from POST /ask
-    if method == "POST" and path == "/ask" and status.startswith("200"):
+    # Intercept only successful JSON responses from POST /ask2
+    if method == "POST" and path == "/ask2" and status.startswith("200"):
         try:
             obj = json.loads(body.decode("utf-8"))
             ans = obj.get("answer")

--- a/wsgi_refine_wrapper.py
+++ b/wsgi_refine_wrapper.py
@@ -141,8 +141,8 @@ def application(environ, start_response):
     status = captured.get("status","200 OK")
     headers = captured.get("headers",[])
 
-    # Only touch POST /ask JSON 200 responses when REFINE=on
-    path_ok   = environ.get("PATH_INFO","") in ("/ask",)
+    # Only touch POST /ask2 JSON 200 responses when REFINE=on
+    path_ok   = environ.get("PATH_INFO","") in ("/ask2",)
     method_ok = environ.get("REQUEST_METHOD","") == "POST"
     if not (REFINE and path_ok and method_ok and status.startswith("200")):
         start_response(status, headers); return [body]


### PR DESCRIPTION
## Summary
- remove the Flask /ask handlers and compatibility shims so only /ask2 remains
- retarget middleware and refinement wrappers to intercept /ask2 directly
- expose POST /ask2 on the FastAPI facade and update health test to assert /ask is gone

## Testing
- pytest tests/test_health_and_contract.py
- pytest tests/test_ask2_contract.py

------
https://chatgpt.com/codex/tasks/task_e_68dff194fed88328b085138d264e9faa