### PR TITLE
Route /ask2 through Gemini pipeline first, with safe fallback (single-source routing)

### DIFF
--- a/app/rag/gemini_cli.py
+++ b/app/rag/gemini_cli.py
@@ -2,10 +2,12 @@
 from __future__ import annotations
 
 import json
+import logging
 import os
+import re
 import subprocess
 import threading
-from typing import Optional
+from typing import Dict, Optional
 
 _DEFAULT_TIMEOUT = float(os.getenv("RAG_GEMINI_TIMEOUT", "8"))
 _DEFAULT_MODEL = os.getenv("GEMINI_MODEL", "gemini-2.5-flash")
@@ -54,13 +56,32 @@ def _extract_text(payload: object) -> Optional[str]:
 _FLAG_LOCK = threading.Lock()
 _FLAG_SUPPORTS_LONG: Optional[bool] = None
 _CLI_AVAILABLE: Optional[bool] = None
+_FLAG_PLAN: Optional[Dict[str, str]] = None
 _LAST_ERROR: Optional[GeminiCLIError] = None
+
+_LOGGER = logging.getLogger("app.gemini.cli")
+
+
+def _capture_help(binary: str) -> str:
+    try:
+        help_proc = subprocess.run(
+            [binary, "--help"],
+            capture_output=True,
+            text=True,
+            timeout=_DETECT_TIMEOUT,
+            check=False,
+        )
+    except (FileNotFoundError, subprocess.SubprocessError, OSError) as exc:
+        _LOGGER.debug("gemini_cli_help_failed: %s", exc)
+        return ""
+
+    return ((help_proc.stdout or "") + "\n" + (help_proc.stderr or "")).lower()
 
 
 def detect_gemini_flags() -> bool:
     """Probe the installed CLI once to determine whether long flags are supported."""
 
-    global _FLAG_SUPPORTS_LONG, _CLI_AVAILABLE
+    global _FLAG_SUPPORTS_LONG, _CLI_AVAILABLE, _FLAG_PLAN
 
     with _FLAG_LOCK:
         if _FLAG_SUPPORTS_LONG is not None:
@@ -76,28 +97,51 @@ def detect_gemini_flags() -> bool:
                 timeout=_DETECT_TIMEOUT,
                 check=False,
             )
-        except (FileNotFoundError, subprocess.SubprocessError, OSError):
+        except (FileNotFoundError, subprocess.SubprocessError, OSError) as exc:
+            _LOGGER.debug("gemini_cli_version_failed: %s", exc)
             _CLI_AVAILABLE = False
             _FLAG_SUPPORTS_LONG = False
+            _FLAG_PLAN = {}
             return _FLAG_SUPPORTS_LONG
 
         _CLI_AVAILABLE = True
 
-        try:
-            help_proc = subprocess.run(
-                [binary, "--help"],
-                capture_output=True,
-                text=True,
-                timeout=_DETECT_TIMEOUT,
-                check=False,
-            )
-        except (FileNotFoundError, subprocess.SubprocessError, OSError):
-            _FLAG_SUPPORTS_LONG = False
-            return _FLAG_SUPPORTS_LONG
+        output = _capture_help(binary)
 
-        output = ((help_proc.stdout or "") + "\n" + (help_proc.stderr or "")).lower()
-        _FLAG_SUPPORTS_LONG = "--model" in output and "--json_input" in output
+        plan: Dict[str, str] = {}
+        if "--model" in output:
+            plan["model_long"] = "--model"
+        if "-m" in output:
+            plan["model_short"] = "-m"
+        if "--json_input" in output:
+            plan["json_long"] = "--json_input"
+        if re.search(r"\s-j[\s,]", output):
+            plan["json_short"] = "-j"
+        if "--prompt" in output:
+            plan["prompt_long"] = "--prompt"
+        if re.search(r"\s-p[\s,]", output):
+            plan["prompt_short"] = "-p"
+
+        _FLAG_PLAN = plan
+        supports_json = any(key in plan for key in ("json_long", "json_short"))
+        supports_model = any(key in plan for key in ("model_long", "model_short"))
+        supports_prompt_long = "prompt_long" in plan
+        supports_prompt_short = "prompt_short" in plan
+
+        _FLAG_SUPPORTS_LONG = bool(plan.get("model_long") and plan.get("json_long") and plan.get("prompt_long"))
+        _LOGGER.info(
+            "gemini_cli_capabilities supports_json=%s supports_model_alias=%s supports_prompt_long=%s supports_prompt_short=%s",
+            supports_json,
+            supports_model,
+            supports_prompt_long,
+            supports_prompt_short,
+        )
         return _FLAG_SUPPORTS_LONG
+
+
+def _get_flag_plan() -> Dict[str, str]:
+    with _FLAG_LOCK:
+        return dict(_FLAG_PLAN or {})
 
 
 def gemini_cli_available() -> bool:
@@ -132,15 +176,41 @@ def gemini_call(prompt: str, timeout: Optional[float] = None, model: Optional[st
     binary = os.getenv("GEMINI_BIN", _DEFAULT_BIN)
 
     supports_long = detect_gemini_flags()
+    flag_plan = _get_flag_plan()
 
     if _CLI_AVAILABLE is False:
         _LAST_ERROR = GeminiCLIError("gemini_cli_unavailable")
         return None
 
-    if supports_long:
-        cmd = [binary, "--model", effective_model, "--json_input", "-p", prompt]
+    cmd = [binary]
+
+    if supports_long and flag_plan.get("model_long"):
+        cmd.extend([flag_plan["model_long"], effective_model])
+    elif flag_plan.get("model_short"):
+        cmd.extend([flag_plan["model_short"], effective_model])
+    elif flag_plan.get("model_long"):
+        cmd.extend([flag_plan["model_long"], effective_model])
+
+    if supports_long and flag_plan.get("json_long"):
+        cmd.append(flag_plan["json_long"])
+    elif flag_plan.get("json_short"):
+        cmd.append(flag_plan["json_short"])
+    elif flag_plan.get("json_long"):
+        cmd.append(flag_plan["json_long"])
+
+    prompt_flag: Optional[str]
+    if supports_long and flag_plan.get("prompt_long"):
+        prompt_flag = flag_plan["prompt_long"]
+    elif flag_plan.get("prompt_short"):
+        prompt_flag = flag_plan["prompt_short"]
     else:
-        cmd = [binary, "-m", effective_model, "-j", "-p", prompt]
+        prompt_flag = flag_plan.get("prompt_long")
+
+    stdin_input: Optional[str] = None
+    if prompt_flag:
+        cmd.extend([prompt_flag, prompt])
+    else:
+        stdin_input = prompt
 
     try:
         proc = subprocess.run(
@@ -149,6 +219,7 @@ def gemini_call(prompt: str, timeout: Optional[float] = None, model: Optional[st
             text=True,
             timeout=effective_timeout,
             check=False,
+            input=stdin_input,
         )
     except (FileNotFoundError, subprocess.TimeoutExpired) as exc:
         _LAST_ERROR = GeminiCLIError("gemini_cli_unavailable", stderr=str(exc))

--- a/app/retrieval/adapter.py
+++ b/app/retrieval/adapter.py
@@ -1,0 +1,56 @@
+from typing import Any, Dict, Tuple
+
+try:
+    from app.retrieval.service import run_pipeline, _strip_sources_block  # type: ignore
+except Exception:  # pragma: no cover - optional dependency
+    run_pipeline = None  # type: ignore
+
+    def _strip_sources_block(answer: str) -> str:  # type: ignore
+        return answer
+
+
+def normalize_shape(payload: Dict[str, Any]) -> Dict[str, Any]:
+    """Normalize pipeline payloads into the /ask2 contract."""
+
+    data = payload or {}
+    answer_text = data.get("answer") or data.get("text") or data.get("summary") or ""
+    answer_text = _strip_sources_block(answer_text)
+    sources = data.get("sources") or data.get("chunks") or data.get("results") or []
+    if not isinstance(sources, list):
+        sources = []
+    meta = data.get("meta") or {}
+    if not isinstance(meta, dict):
+        meta = {}
+    contexts = data.get("contexts") or []
+    if not isinstance(contexts, list):
+        contexts = []
+    return {"answer": answer_text, "sources": sources, "contexts": contexts, "meta": meta}
+
+
+def ask2_pipeline_first(question: str, k: int, *, client_ip: str = "unknown") -> Tuple[Dict[str, Any], int]:
+    """Attempt Gemini-first routing before falling back to legacy behavior."""
+
+    if callable(run_pipeline):
+        try:
+            payload = run_pipeline(question, k=k, client_ip=client_ip)  # type: ignore[misc]
+        except Exception as exc:  # pragma: no cover - defensive fallback
+            shaped = {
+                "answer": "",
+                "sources": [],
+                "contexts": [],
+                "meta": {"routing": "gemini_first_fail", "error": str(exc)},
+            }
+            return shaped, 599
+        if isinstance(payload, dict):
+            shaped = normalize_shape(payload)
+            meta = dict(shaped.get("meta") or {})
+            meta["routing"] = "gemini_first"
+            shaped["meta"] = meta
+            return shaped, 200
+    shaped = {
+        "answer": "",
+        "sources": [],
+        "contexts": [],
+        "meta": {"routing": "no_pipeline"},
+    }
+    return shaped, 598

--- a/app/retrieval/gemini_gateway.py
+++ b/app/retrieval/gemini_gateway.py
@@ -14,7 +14,7 @@ from app.rag.gemini_cli import GeminiCLIError, gemini_call, get_last_error
 from .settings import settings
 
 
-LOGGER = logging.getLogger("gemini-gateway")
+LOGGER = logging.getLogger("app.gemini")
 
 
 def _parse_json(text: Optional[str]) -> Optional[Dict[str, Any]]:

--- a/scripts/deploy_minimal.sh
+++ b/scripts/deploy_minimal.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+set -euo pipefail
+TS=$(date +%Y%m%d-%H%M%S)
+APP=/opt/sustainacore-ai
+sudo mkdir -p /opt/backups
+
+echo "[1/4] Backup"
+sudo tar -C / -czf /opt/backups/sustainacore-ai_${TS}.tgz \
+  ${APP}/app.py \
+  ${APP}/app/retrieval \
+  ${APP}/.ask_facade/wsgi_ask_facade.py || true
+
+echo "[2/4] Sync changed files"
+# rsync your built tree to /opt/sustainacore-ai/, or copy the specific files:
+#   sudo rsync -av app.py ${APP}/
+#   sudo rsync -av app/retrieval/adapter.py ${APP}/app/retrieval/
+#   sudo rsync -av scripts/verify_ask2.sh ${APP}/scripts/
+
+echo "[3/4] Restart"
+sudo systemctl restart sustainacore-ai
+sleep 1
+systemctl --no-pager -l status sustainacore-ai | sed -n '1,40p'
+
+echo "[4/4] Verify"
+bash scripts/verify_ask2.sh
+
+# Rollback commands:
+# sudo tar -C / -xzf /opt/backups/sustainacore-ai_${TS}.tgz
+# sudo systemctl restart sustainacore-ai
+

--- a/scripts/verify_ask2.sh
+++ b/scripts/verify_ask2.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+set -euo pipefail
+HOST="${HOST:-localhost}"
+PORT="${PORT:-8080}"
+
+echo "== Legacy body =="
+curl -sS "http://${HOST}:${PORT}/ask2" -H 'Content-Type: application/json' \
+  -d '{"question":"Is Microsoft in the TECH100 Index?","top_k":6}' | jq '.answer,.contexts,.meta'
+
+echo "== APEX body =="
+curl -sS "http://${HOST}:${PORT}/ask2" -H 'Content-Type: application/json' \
+  -d '{"q":"Is Microsoft in the TECH100 Index?","top_k":6,"refine":"off"}' | jq '.answer,.contexts,.meta'
+
+echo "== Check logs (needs journald on host) =="
+journalctl -u sustainacore-ai --since '2 minutes ago' --no-pager | egrep 'gemini=ok|gemini=fail' || true
+

--- a/tests/test_ask2_behaviors.py
+++ b/tests/test_ask2_behaviors.py
@@ -15,6 +15,12 @@ import app as ask_app
 
 @pytest.fixture(autouse=True)
 def disable_external_calls(monkeypatch):
+    from app.retrieval import adapter as retrieval_adapter
+
+    def _raise_pipeline(*_args, **_kwargs):
+        raise RuntimeError("pipeline disabled")
+
+    monkeypatch.setattr(retrieval_adapter, "run_pipeline", _raise_pipeline)
     monkeypatch.setattr(ask_app, "_gemini_run_pipeline", None)
     monkeypatch.setattr(ask_app, "embed_text", lambda text, settings=None: [0.0])
     monkeypatch.setattr(ask_app, "_top_k_by_vector", lambda *args, **kwargs: [])

--- a/tests/test_ask2_pipeline_first.py
+++ b/tests/test_ask2_pipeline_first.py
@@ -1,0 +1,52 @@
+import sys
+from pathlib import Path
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
+from app import app as flask_app
+
+
+def test_pipeline_first_success(monkeypatch):
+    from app.retrieval import adapter
+    from app import ask2 as route_handler, ask2_pipeline_first as route_adapter
+
+    called = {"count": 0}
+
+    def fake_run(question, k, client_ip=None):
+        called["count"] += 1
+        return {
+            "answer": "Hello",
+            "contexts": [{"id": "x"}],
+            "sources": [{"id": "s1"}],
+            "meta": {"compose": {"status": "ok"}},
+        }
+
+    monkeypatch.setattr(adapter, "run_pipeline", fake_run)
+    assert adapter.run_pipeline is fake_run
+    assert route_adapter is adapter.ask2_pipeline_first
+    monkeypatch.setitem(flask_app.view_functions, "ask2", route_handler)
+    client = flask_app.test_client()
+    response = client.post("/ask2", json={"q": "Ping", "top_k": 6})
+    payload = response.get_json()
+    assert response.status_code == 200
+    assert called["count"] == 1
+    assert payload["answer"] == "Hello"
+    assert "Sources:" not in payload["answer"]
+    assert isinstance(payload.get("contexts"), list)
+    assert payload.get("meta", {}).get("routing") == "gemini_first"
+
+
+def test_pipeline_first_fallback(monkeypatch):
+    from app.retrieval import adapter
+
+    def boom(*args, **kwargs):
+        raise RuntimeError("no cli")
+
+    monkeypatch.setattr(adapter, "run_pipeline", boom)
+    client = flask_app.test_client()
+    response = client.post("/ask2", json={"q": "Ping", "top_k": 6})
+    payload = response.get_json()
+    assert response.status_code == 200
+    assert isinstance(payload.get("answer", ""), str)


### PR DESCRIPTION
## Why
Facade vs app.py routing race caused pipeline never to run in production. New single-source ask2 route in app.py calls pipeline first, then legacy fallback.

## What

- Added app/retrieval/adapter.py with ask2_pipeline_first() and normalize_shape().
- Modified app.py /ask2 to call adapter then fallback.
- Ensured contexts pass-through; narrative stripping; logging remains.
- Tests: success + fallback.
- Scripts: deploy + verify.

## Evidence
- Run `bash scripts/verify_ask2.sh` after deploy and capture output showing answers without inline Sources and gemini=ok/fail logs.


------
https://chatgpt.com/codex/tasks/task_e_68e1496a450c832895ebadcd14a91535