### PR TITLE
Restore Oracle retrieval pipeline and add SQL contract tests

### DIFF
--- a/app/retrieval/embedding_client.py
+++ b/app/retrieval/embedding_client.py
@@ -1,0 +1,16 @@
+"""Compatibility wrapper exposing the shared embedding client."""
+
+from __future__ import annotations
+
+from typing import Any, List, Optional
+
+from embedding_client import embed_text as _embed_text
+
+
+def embed_text(text: str, *, timeout: float = 15.0, settings: Optional[Any] = None) -> List[float]:
+    """Proxy to the project-wide embedding helper for local vector generation."""
+
+    return _embed_text(text, timeout=timeout, settings=settings)
+
+
+__all__ = ["embed_text"]

--- a/app/retrieval/settings.py
+++ b/app/retrieval/settings.py
@@ -70,11 +70,11 @@ class Settings:
     oracle_scope_filters: tuple[str, ...] = field(default_factory=lambda: tuple(f.strip().upper() for f in os.environ.get("ORACLE_ALLOWED_FILTERS", "SOURCE_TYPE,TICKER,DATE_FROM,DATE_TO,DOC_ID,SOURCE_ID").split(",") if f.strip()))
 
     oracle_embed_model: str = field(default_factory=lambda: os.environ.get("ORACLE_EMBED_MODEL", "AI$MINILM_L6_V2"))
-    oracle_embed_proc: str = field(default_factory=lambda: os.environ.get("ORACLE_EMBED_PROC", "AI_VECTOR.EMBED_TEXT"))
+    oracle_embed_proc: str = field(default_factory=lambda: os.environ.get("ORACLE_EMBED_PROC", "LOCAL_EMBEDDINGS"))
     oracle_embed_sql: str = field(
         default_factory=lambda: os.environ.get(
             "ORACLE_EMBED_SQL",
-            "SELECT AI_VECTOR.EMBED_TEXT(:model, :text) FROM DUAL",
+            "LOCAL_EMBEDDINGS",
         )
     )
     oracle_knn_metric: Literal["COSINE", "DOT"] = field(default_factory=lambda: os.environ.get("ORACLE_KNN_METRIC", "COSINE").upper() == "DOT" and "DOT" or "COSINE")

--- a/config/env.sample
+++ b/config/env.sample
@@ -22,7 +22,7 @@ WALLET_PWD=replace-me
 
 # Oracle embedding configuration
 ORACLE_EMBED_MODEL=AI$MINILM_L6_V2
-ORACLE_EMBED_SQL=SELECT AI_VECTOR.EMBED_TEXT(:model, :text) FROM DUAL
+ORACLE_EMBED_SQL=LOCAL_EMBEDDINGS
 
 # Embedding service configuration
 EMBED_MODEL_NAME=all-minilm

--- a/db_helper.py
+++ b/db_helper.py
@@ -190,7 +190,9 @@ def top_k_by_vector(vec, k=5, *, filters=None):
     k = max(1, int(k or 1))
     where_clause, binds = _build_filter_clause(filters or {})
     sql = (
-        f"SELECT doc_id, chunk_ix, title, source_url, source_type, source_id, chunk_text,                VECTOR_DISTANCE({column_name}, :v) AS dist FROM {table_name}{where_clause}                ORDER BY VECTOR_DISTANCE({column_name}, :v) FETCH FIRST {k} ROWS ONLY"
+        "SELECT doc_id, chunk_ix, title, source_url, source_type, source_id, chunk_text, "
+        f"VECTOR_DISTANCE(:v, {column_name}) AS dist FROM {table_name}{where_clause} "
+        f"ORDER BY VECTOR_DISTANCE(:v, {column_name}) FETCH FIRST {k} ROWS ONLY"
     )
 
     with _conn() as conn:

--- a/tests/test_ask2_pipeline_first.py
+++ b/tests/test_ask2_pipeline_first.py
@@ -97,6 +97,7 @@ def test_pipeline_compose_failure(monkeypatch):
     assert shaped["meta"]["routing"] == "gemini_first_fail"
     assert shaped["contexts"]
     assert "Sources:" not in shaped["answer"]
+    assert shaped["meta"].get("note") == "gemini_compose_failed"
 
 
 def test_fs_backfill_enabled(monkeypatch):

--- a/tests/test_oracle_schema_probe.py
+++ b/tests/test_oracle_schema_probe.py
@@ -95,7 +95,7 @@ def test_top_k_by_vector_executes_query(monkeypatch):
     result = db_helper.top_k_by_vector([0.1, 0.2, 0.3], k=2)
 
     cursor = cursor_holder["cursor"]
-    assert "VECTOR_DISTANCE(EMBEDDING, :v)" in cursor.executed_sql
+    assert "VECTOR_DISTANCE(:v, EMBEDDING)" in cursor.executed_sql
     assert "AI_VECTOR" not in cursor.executed_sql
     assert "FETCH FIRST 2 ROWS ONLY" in cursor.executed_sql
     assert result[0]["doc_id"] == 1

--- a/tests/test_oracle_sql.py
+++ b/tests/test_oracle_sql.py
@@ -1,0 +1,131 @@
+import types
+
+import pytest
+
+import db_helper
+from app.retrieval import oracle_retriever
+
+
+class _DummyCursor:
+    def __init__(self, description):
+        self.description = description
+        self.executed_sql = None
+        self.executed_params = None
+
+    def setinputsizes(self, **kwargs):  # pragma: no cover - interface only
+        self.inputsizes = kwargs
+
+    def execute(self, sql, params):
+        self.executed_sql = sql
+        self.executed_params = params
+
+    def fetchall(self):
+        return [(1, 0, "Doc", "SRC", "Source name", "https://example", "Snippet", 0.12)]
+
+
+class _DummyConn:
+    def __init__(self, description):
+        self._cursor = _DummyCursor(description)
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        return False
+
+    def cursor(self):
+        return self._cursor
+
+
+@pytest.fixture(autouse=True)
+def _clear_vector_cache():
+    db_helper.get_vector_column.cache_clear()
+    yield
+    db_helper.get_vector_column.cache_clear()
+
+
+def test_top_k_by_vector_sql_contract(monkeypatch):
+    description = [
+        ("DOC_ID",),
+        ("CHUNK_IX",),
+        ("TITLE",),
+        ("SOURCE_URL",),
+        ("SOURCE_TYPE",),
+        ("SOURCE_ID",),
+        ("CHUNK_TEXT",),
+        ("DIST",),
+    ]
+    holder = {}
+
+    def fake_conn():
+        conn = _DummyConn(description)
+        holder["cursor"] = conn.cursor()
+        return conn
+
+    monkeypatch.setattr(db_helper, "oracledb", types.SimpleNamespace(DB_TYPE_VECTOR=object()))
+    monkeypatch.setattr(db_helper, "_conn", fake_conn)
+    monkeypatch.setattr(
+        db_helper,
+        "get_vector_column",
+        lambda table="ESG_DOCS": {"table": "ESG_DOCS", "column": "EMBEDDING", "dimension": 3},
+    )
+
+    result = db_helper.top_k_by_vector([0.1, 0.2, 0.3], k=5)
+
+    cursor = holder["cursor"]
+    assert cursor.executed_sql.count("FETCH FIRST 5 ROWS ONLY") == 1
+    assert "VECTOR_DISTANCE(:v, EMBEDDING)" in cursor.executed_sql
+    assert all(banned not in cursor.executed_sql for banned in ["AI_VECTOR", "UTL_HTTP", "APEX_WEB_SERVICE", "DBMS_CLOUD"])
+    assert "k" not in cursor.executed_params
+    assert result[0]["doc_id"] == 1
+
+
+def test_oracle_retriever_vector_sql(monkeypatch):
+    description = [
+        ("DOC_ID",),
+        ("CHUNK_IX",),
+        ("SOURCE_ID",),
+        ("SOURCE_NAME",),
+        ("TITLE",),
+        ("SOURCE_URL",),
+        ("CHUNK_TEXT",),
+        ("DIST",),
+    ]
+    holder = {}
+
+    class DummyConn:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            return False
+
+        def cursor(self):
+            cursor = _DummyCursor(description)
+            holder["cursor"] = cursor
+            return cursor
+
+    monkeypatch.setattr(oracle_retriever, "oracledb", types.SimpleNamespace(DB_TYPE_VECTOR=object()))
+    monkeypatch.setattr(oracle_retriever, "_ORACLE_AVAILABLE", True)
+
+    retr = oracle_retriever.OracleRetriever()
+    retr._metadata_ready = True
+    retr._available_columns = {
+        retr.doc_id_column,
+        retr.chunk_ix_column,
+        retr.source_id_column,
+        retr.source_column,
+        retr.title_column,
+        retr.url_column,
+        retr.text_column,
+        retr.embedding_column,
+    }
+
+    rows = retr._vector_query(DummyConn(), [0.1, 0.2, 0.3], filters={}, k=4)
+
+    cursor = holder["cursor"]
+    assert "VECTOR_DISTANCE(:vec, EMBEDDING" in cursor.executed_sql
+    assert "FETCH FIRST 4 ROWS ONLY" in cursor.executed_sql
+    assert ":k" not in cursor.executed_sql
+    assert all(banned not in cursor.executed_sql for banned in ["AI_VECTOR", "UTL_HTTP", "APEX_WEB_SERVICE", "DBMS_CLOUD"])
+    assert rows and rows[0]["doc_id"] == 1


### PR DESCRIPTION
## Summary
- replace the Oracle retriever to use the shared local embedding client and inline FETCH FIRST limits
- remove any AI_VECTOR embed defaults from settings and sample env configuration
- add regression tests covering Oracle SQL generation and Gemini-first compose failure handling

## Testing
- python -m pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68e19c0d923c83288e85f6ae143250fe