### PR TITLE
[codex] Harden SC_IDX pipeline state persistence

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -231,6 +231,8 @@ dmesg -T | egrep -i "oom|out of memory|killed process" | tail -n 60
 - The live scheduler path is `/home/opc/Sustainacore`; it should resolve to a versioned release checkout under `/opt/sustainacore-sc-idx-*`.
 - Always prove the active scheduler revision with `readlink -f /home/opc/Sustainacore` and `git -C "$(readlink -f /home/opc/Sustainacore)" rev-parse --short HEAD`.
 - Pipeline state is tracked in `SC_IDX_PIPELINE_STATE`; `python3 tools/index_engine/run_pipeline.py` resumes safe completed nodes by default.
+- Oracle stage-state rows are intentionally compact; the full same-run stage payload also lives in
+  `tools/audit/output/pipeline_state_latest.json` and is keyed by `run_id`, not only by day.
 - Force a full restart with `python3 tools/index_engine/run_pipeline.py --restart`.
 - Use `python3 tools/index_engine/run_pipeline.py --smoke --smoke-scenario degraded --restart` for a no-provider smoke run.
 - Terminal outcomes are:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -228,6 +228,8 @@ dmesg -T | egrep -i "oom|out of memory|killed process" | tail -n 60
 - LangGraph is the primary orchestration pattern for the SC_IDX / TECH100 operational pipeline on VM1.
 - Primary entrypoint: `python3 tools/index_engine/run_pipeline.py`.
 - Primary systemd scheduler: `sc-idx-pipeline.timer` -> `sc-idx-pipeline.service`.
+- The live scheduler path is `/home/opc/Sustainacore`; it should resolve to a versioned release checkout under `/opt/sustainacore-sc-idx-*`.
+- Always prove the active scheduler revision with `readlink -f /home/opc/Sustainacore` and `git -C "$(readlink -f /home/opc/Sustainacore)" rev-parse --short HEAD`.
 - Pipeline state is tracked in `SC_IDX_PIPELINE_STATE`; `python3 tools/index_engine/run_pipeline.py` resumes safe completed nodes by default.
 - Force a full restart with `python3 tools/index_engine/run_pipeline.py --restart`.
 - Use `python3 tools/index_engine/run_pipeline.py --smoke --smoke-scenario degraded --restart` for a no-provider smoke run.
@@ -257,6 +259,7 @@ dmesg -T | egrep -i "oom|out of memory|killed process" | tail -n 60
 - Imputed replacement guardrails: `SC_IDX_IMPUTED_REPLACEMENT_DAYS` (default 30) and `SC_IDX_IMPUTED_REPLACEMENT_LIMIT` (default 10).
 - Oracle evidence files on failure: `tools/audit/output/oracle_health_*.txt` (no secrets).
 - Systemd SC_IDX units load `/etc/sustainacore/index.env` for non-secret pipeline config (e.g., `MARKET_DATA_API_BASE_URL`).
+- Exit code `2` is a terminal SC_IDX blocked/non-advancing outcome and must not be auto-restarted by systemd.
 - Failure alert email policy:
   - `failed` and `blocked` attempt email by default
   - `stale` attempts email by default, even when the graph technically concluded as `clean_skip` or `success_with_degradation`

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,5 +1,5 @@
 SustainaCore — Autopilot rules for Codex.
-<!-- cspell:ignore certifi chdir LOOKBACK noreload ionice sysconfig pycache -->
+<!-- cspell:ignore certifi chdir LOOKBACK noreload ionice readlink sysconfig pycache -->
 - Keep /ask2 contract (q,k -> {answer,sources,meta})
 - Build: python3 -m venv .venv && source .venv/bin/activate && pip -U pip wheel && pip -r requirements.txt && pytest -q || true
 - Run: uvicorn app.retrieval.app:app --host 0.0.0.0 --port 8080

--- a/app/index_engine/orchestration.py
+++ b/app/index_engine/orchestration.py
@@ -285,6 +285,31 @@ def _coerce_date(value: Any) -> _dt.date | None:
     return None
 
 
+def _context_trading_days(
+    context: dict[str, Any],
+    *,
+    default_end: _dt.date | None = None,
+) -> list[_dt.date]:
+    raw_days = context.get("trading_days")
+    if isinstance(raw_days, list):
+        parsed_days = sorted({_coerce_date(day) for day in raw_days if _coerce_date(day) is not None})
+        if parsed_days:
+            return parsed_days
+
+    upper_bound = (
+        _coerce_date(context.get("calendar_max_date"))
+        or _coerce_date(context.get("candidate_end_date"))
+        or _coerce_date(context.get("ready_end_date"))
+        or _coerce_date(context.get("expected_target_date"))
+        or _coerce_date(context.get("calc_end_date"))
+        or _coerce_date(context.get("levels_max_after"))
+        or default_end
+    )
+    if upper_bound is None:
+        return []
+    return engine_db.fetch_trading_days(BASE_DATE, upper_bound)
+
+
 def _fetch_scalar(sql: str, binds: dict[str, Any] | None = None) -> Any:
     with get_connection() as conn:
         cur = conn.cursor()
@@ -792,7 +817,7 @@ class SCIdxPipelineRuntime:
         provider = run_daily._load_provider_module()
         probe_symbol = os.getenv(run_daily.PROBE_SYMBOL_ENV, "SPY")
         candidate_end = _coerce_date(context.get("candidate_end_date"))
-        trading_days = context.get("trading_days") or []
+        trading_days = _context_trading_days(context, default_end=candidate_end)
         if candidate_end is None or not trading_days:
             return {
                 "status": "FAILED",
@@ -972,7 +997,10 @@ class SCIdxPipelineRuntime:
         check_module = self._load_completeness_module()
         ingest_module = self._load_ingest_module()
         context = state.get("context") or {}
-        trading_days = context.get("trading_days") or []
+        trading_days = _context_trading_days(
+            context,
+            default_end=_coerce_date(context.get("candidate_end_date")),
+        )
         if not trading_days:
             return {
                 "status": "FAILED",
@@ -1212,7 +1240,7 @@ class SCIdxPipelineRuntime:
                 "error_token": "calc_canon_lag",
             }
 
-        trading_days = context.get("trading_days") or engine_db.fetch_trading_days(BASE_DATE, max_canon_date)
+        trading_days = _context_trading_days(context, default_end=max_canon_date)
         end_day = max(day for day in trading_days if day <= max_canon_date)
         try:
             code = calc_module.main(
@@ -1277,8 +1305,8 @@ class SCIdxPipelineRuntime:
     def portfolio_analytics(self, state: PipelineGraphState) -> dict[str, Any]:
         build_module = self._load_portfolio_analytics_module()
         context = state.get("context") or {}
-        trading_days = context.get("trading_days") or []
         max_level_date = _coerce_date(context.get("levels_max_after")) or db_index_calc.fetch_max_level_date()
+        trading_days = _context_trading_days(context, default_end=max_level_date)
         if max_level_date is None:
             return {"status": "SKIP", "detail": "no_levels_available"}
 

--- a/app/index_engine/run_report.py
+++ b/app/index_engine/run_report.py
@@ -243,6 +243,8 @@ def _overall_health_label(terminal_status: str | None, freshness_health: Dict[st
 def _primary_stage(stage_results: Dict[str, Dict[str, Any]], terminal_status: str, status_reason: str | None) -> str | None:
     if status_reason and status_reason in stage_results:
         return status_reason
+    if terminal_status == "success":
+        return None
     target_statuses = {
         "failed": {"FAILED", "BLOCKED"},
         "blocked": {"BLOCKED"},

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -100,6 +100,10 @@
 - Operator entrypoint: `python3 tools/index_engine/run_pipeline.py`.
 - Primary scheduler: `sc-idx-pipeline.timer` -> `sc-idx-pipeline.service`.
 - Daily operator report scheduler: `sc-telemetry-report.timer` -> `sc-telemetry-report.service`.
+- The scheduler-facing repo path is `/home/opc/Sustainacore`; on production VM1 it should resolve to a versioned release checkout under `/opt/sustainacore-sc-idx-*`.
+- Verify the live scheduler revision with:
+  - `readlink -f /home/opc/Sustainacore`
+  - `sudo -n -u opc git -C "$(readlink -f /home/opc/Sustainacore)" rev-parse --short HEAD`
 - The graph is deliberately thin and low-memory:
   - no daemon
   - no Redis/Celery
@@ -115,6 +119,7 @@
     deployed checkout
 - Compact run status codes in `SC_IDX_JOB_RUNS`:
   - `OK`, `DEGRADED`, `SKIP`, `ERROR`, `BLOCKED`
+- SC_IDX systemd units treat exit code `2` as a terminal blocked/non-advancing outcome, not a crash to auto-restart.
 - Failure email policy:
   - `failed` and `blocked` attempt email by default
   - `stale` attempts email by default, even when the graph technically concluded

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -1,5 +1,5 @@
 # Sustainacore Operations Guide
-<!-- cspell:ignore cutover sustainacoredb sysconfig -->
+<!-- cspell:ignore cutover readlink sustainacoredb sysconfig -->
 
 ## Embedding parity
 - `EMBED_MODEL_NAME` is the single source of truth for the embedding model used by the service. The previous `OLLAMA_EMBED_MODEL` is read only for backwards compatibility.

--- a/docs/index_engine_langgraph_orchestration.md
+++ b/docs/index_engine_langgraph_orchestration.md
@@ -61,7 +61,9 @@ LangGraph is the orchestrator, but the durability layer is repo-native and Oracl
 - `SC_IDX_PIPELINE_STATE`
   - node-level persisted state
   - stage status codes: `OK`, `DEGRADED`, `SKIP`, `FAILED`, `BLOCKED`
-  - JSON details store attempts, counts, warnings, and remediation
+  - Oracle rows keep compact JSON details so node state does not overflow `VARCHAR2(4000)`
+  - the full same-run payload is also written to `tools/audit/output/pipeline_state_latest.json`
+    and is keyed by `run_id`, not just by UTC day
 - `SC_IDX_JOB_RUNS`
   - run-level summary row
   - short terminal codes: `OK`, `DEGRADED`, `SKIP`, `ERROR`, `BLOCKED`

--- a/docs/index_engine_langgraph_orchestration.md
+++ b/docs/index_engine_langgraph_orchestration.md
@@ -1,3 +1,4 @@
+<!-- cspell:ignore VARCHAR -->
 # SC_IDX LangGraph orchestration
 
 ## Why this exists

--- a/docs/runbooks/pipeline_scheduler.md
+++ b/docs/runbooks/pipeline_scheduler.md
@@ -64,6 +64,7 @@ Do not print env contents in logs or docs.
 - ingest + pipeline use the shared lock `/tmp/sc_idx_pipeline.lock` via `flock -n`
 - primary pipeline runtime limit: `RuntimeMaxSec=3600`
 - ingest runtime limit: `RuntimeMaxSec=7200`
+- terminal blocked/guard exits use code `2` and should not be auto-restarted by systemd
 - restart storm guardrails remain in the units through `StartLimit*`
 - retries inside the graph are bounded and stage-specific
 
@@ -84,6 +85,8 @@ Do not print env contents in logs or docs.
 systemctl list-timers --all | rg -i "sc-idx"
 systemctl status sc-idx-pipeline.service
 systemctl status sc-telemetry-report.service
+readlink -f /home/opc/Sustainacore
+sudo -n -u opc git -C "$(readlink -f /home/opc/Sustainacore)" rev-parse --short HEAD
 sudo journalctl -u sc-idx-pipeline.service -n 200 --no-pager
 sudo journalctl -u sc-telemetry-report.service -n 200 --no-pager
 sudo -n systemd-run --wait --collect --pipe \
@@ -129,6 +132,10 @@ Service-equivalent run:
 sudo systemctl start sc-idx-pipeline.service
 sudo systemctl start sc-telemetry-report.service
 ```
+
+If repeated `BLOCKED` runs happen with no active SC_IDX process, inspect the effective unit config
+and verify exit code `2` is listed under `SuccessExitStatus` / `RestartPreventExitStatus` before
+rerunning the pipeline.
 
 ## Alert behavior
 

--- a/docs/runbooks/pipeline_scheduler.md
+++ b/docs/runbooks/pipeline_scheduler.md
@@ -72,6 +72,9 @@ Do not print env contents in logs or docs.
 
 - latest `SC_IDX_JOB_RUNS` row for `job_name='sc_idx_pipeline'` is `OK`, `DEGRADED`, or `SKIP`
 - latest `SC_IDX_PIPELINE_STATE` rows show the node sequence reaching `persist_terminal_status`
+- if a stage detail payload is too large for Oracle, `SC_IDX_PIPELINE_STATE` keeps the compact node
+  summary while the full same-run details remain in
+  `tools/audit/output/pipeline_state_latest.json`
 - `SC_IDX_TRADING_DAYS`, `SC_IDX_PRICES_CANON`, `SC_IDX_LEVELS`, and `SC_IDX_STATS_DAILY` max dates align where expected
 - `SC_IDX_PORTFOLIO_ANALYTICS_DAILY` and `SC_IDX_PORTFOLIO_POSITION_DAILY` match the latest `SC_IDX_LEVELS` trade date after a successful run
 - latest report exists under `tools/audit/output/pipeline_runs/`

--- a/infra/systemd/README.md
+++ b/infra/systemd/README.md
@@ -22,7 +22,7 @@ Units live under `infra/systemd/`:
 ### Behavior
 
 - Runs the primary VM1 LangGraph orchestration path:
-  - `/usr/bin/python3 /home/opc/Sustainacore/tools/index_engine/run_pipeline.py`
+  - `/home/opc/Sustainacore/.venv/bin/python /home/opc/Sustainacore/tools/index_engine/run_pipeline.py`
 - Coordinates preflight, target-date planning, readiness, ingest, completeness, imputation, index/statistics, reporting, alerting, telemetry, terminal persistence, and lock release.
 - Uses the same VM1 env files:
   - `/etc/sustainacore/db.env`
@@ -32,6 +32,7 @@ Units live under `infra/systemd/`:
 - Writes telemetry under `tools/audit/output/pipeline_telemetry/`.
 - Writes health snapshots under `tools/audit/output/pipeline_health_latest.txt`, including
   `repo_root`, `repo_head`, freshness dates, and `last_error`.
+- Treats exit code `2` as a terminal blocked/non-advancing outcome so systemd does not auto-restart into the same lock.
 - Timer schedule: **00:30, 05:30, 09:30, 13:30 UTC** with `Persistent=true`.
 
 ### Manual run

--- a/infra/systemd/sc-idx-completeness-check.service
+++ b/infra/systemd/sc-idx-completeness-check.service
@@ -20,7 +20,9 @@ ExecStartPre=/bin/ls -l /etc/sustainacore/db.env /etc/sustainacore/index.env /et
 ExecStartPre=/usr/bin/namei -l /etc/sustainacore/db.env
 ExecStartPre=/usr/bin/namei -l /etc/sustainacore/index.env
 ExecStartPre=/usr/bin/namei -l /etc/sustainacore-ai/secrets.env
-ExecStart=/usr/bin/flock -n /tmp/sc_idx_pipeline.lock /usr/bin/python3 /home/opc/Sustainacore/tools/index_engine/check_price_completeness.py --since-base --end today --email-on-fail
+ExecStart=/usr/bin/flock -n /tmp/sc_idx_pipeline.lock /home/opc/Sustainacore/.venv/bin/python /home/opc/Sustainacore/tools/index_engine/check_price_completeness.py --since-base --end today --email-on-fail
+SuccessExitStatus=2
+RestartPreventExitStatus=2
 Restart=on-failure
 RestartSec=10
 

--- a/infra/systemd/sc-idx-index-calc.service
+++ b/infra/systemd/sc-idx-index-calc.service
@@ -20,8 +20,9 @@ ExecStartPre=/bin/ls -l /etc/sustainacore/db.env /etc/sustainacore/index.env /et
 ExecStartPre=/usr/bin/namei -l /etc/sustainacore/db.env
 ExecStartPre=/usr/bin/namei -l /etc/sustainacore/index.env
 ExecStartPre=/usr/bin/namei -l /etc/sustainacore-ai/secrets.env
-ExecStart=/usr/bin/flock -n /tmp/sc_idx_pipeline.lock /usr/bin/python3 /home/opc/Sustainacore/tools/index_engine/calc_index.py --since-base --strict --preflight-self-heal --diagnose-missing --email-on-fail
+ExecStart=/usr/bin/flock -n /tmp/sc_idx_pipeline.lock /home/opc/Sustainacore/.venv/bin/python /home/opc/Sustainacore/tools/index_engine/calc_index.py --since-base --strict --preflight-self-heal --diagnose-missing --email-on-fail
 SuccessExitStatus=2
+RestartPreventExitStatus=2
 Restart=on-failure
 RestartSec=10
 

--- a/infra/systemd/sc-idx-pipeline.service
+++ b/infra/systemd/sc-idx-pipeline.service
@@ -23,7 +23,9 @@ ExecStartPre=/bin/ls -l /etc/sustainacore/db.env /etc/sustainacore/index.env /et
 ExecStartPre=/usr/bin/namei -l /etc/sustainacore/db.env
 ExecStartPre=/usr/bin/namei -l /etc/sustainacore/index.env
 ExecStartPre=/usr/bin/namei -l /etc/sustainacore-ai/secrets.env
-ExecStart=/usr/bin/flock -n /tmp/sc_idx_pipeline.lock /usr/bin/python3 /home/opc/Sustainacore/tools/index_engine/run_pipeline.py
+ExecStart=/usr/bin/flock -n /tmp/sc_idx_pipeline.lock /home/opc/Sustainacore/.venv/bin/python /home/opc/Sustainacore/tools/index_engine/run_pipeline.py
+SuccessExitStatus=2
+RestartPreventExitStatus=2
 Restart=on-failure
 RestartSec=60
 

--- a/infra/systemd/sc-idx-price-ingest.service
+++ b/infra/systemd/sc-idx-price-ingest.service
@@ -23,7 +23,9 @@ ExecStartPre=/bin/ls -l /etc/sustainacore/db.env /etc/sustainacore/index.env /et
 ExecStartPre=/usr/bin/namei -l /etc/sustainacore/db.env
 ExecStartPre=/usr/bin/namei -l /etc/sustainacore/index.env
 ExecStartPre=/usr/bin/namei -l /etc/sustainacore-ai/secrets.env
-ExecStart=/usr/bin/flock -n /tmp/sc_idx_pipeline.lock /usr/bin/python3 /home/opc/Sustainacore/tools/index_engine/run_daily.py
+ExecStart=/usr/bin/flock -n /tmp/sc_idx_pipeline.lock /home/opc/Sustainacore/.venv/bin/python /home/opc/Sustainacore/tools/index_engine/run_daily.py
+SuccessExitStatus=2
+RestartPreventExitStatus=2
 Restart=on-failure
 RestartSec=60
 

--- a/ops/README.md
+++ b/ops/README.md
@@ -62,7 +62,7 @@ Because preflight skips gracefully, only real execution failures trigger these a
 
 Manual deploys are also available through **Actions → Deploy after Canary → Run workflow**, optionally providing a `sha` input.
 
-## VM1 git-based deploy (no manual rsync)
+## VM1 git-based deploy (clean scheduler release)
 
 On VM1, `sustainacore-ai.service` runs from `/opt/sustainacore-ai` and the SC_IDX scheduler
 services run from `/home/opc/Sustainacore`. To keep the API and daily TECH100 pipeline on the
@@ -72,8 +72,10 @@ same reviewed revision without manual file syncs:
 ops/scripts/deploy_vm1_git.sh
 ```
 
-The script fast-forwards both checkouts, installs deps if needed, restarts
-`sustainacore-ai.service`, and verifies `/healthz`.
+The script fast-forwards `/opt/sustainacore-ai`, clones a fresh SC_IDX release checkout under
+`/opt/sustainacore-sc-idx-*`, repoints `/home/opc/Sustainacore` to that clean release, installs
+the repo-managed `sc-idx-*` systemd units, restarts `sustainacore-ai.service`, and verifies
+`/healthz`.
 
 After any VM1 deploy that touches the daily pipeline, verify the scheduler checkout and portfolio
 freshness in the service-like environment:

--- a/ops/README.md
+++ b/ops/README.md
@@ -1,4 +1,4 @@
-<!-- cspell:ignore readlink -->
+<!-- cspell:ignore readlink repoints -->
 # SustainaCore Operations Guide
 
 This guide explains the forward canary → deploy automation, the reverse "VM → GitHub" loop, and the guardrails that keep alerts actionable without flooding inboxes.

--- a/ops/scripts/deploy_vm.sh
+++ b/ops/scripts/deploy_vm.sh
@@ -1,12 +1,15 @@
 #!/usr/bin/env bash
 set -euo pipefail
-: "${VM_HOST:?Set VM_HOST}"; : "${SSH_KEY:?Set SSH_KEY}"
+
+: "${VM_HOST:?Set VM_HOST}"
+: "${SSH_KEY:?Set SSH_KEY}"
+
 VM_USER="${VM_USER:-opc}"
-APP_DIR="${APP_DIR:-/opt/sustainacore-ai}"
-SC_IDX_DIR="${SC_IDX_DIR:-/home/opc/Sustainacore}"
-SC_IDX_USER="${SC_IDX_USER:-opc}"
-# Stage into the SSH user's home so we can support images where `opc` cannot SSH (e.g., Ubuntu images where `ubuntu` is required).
-STAGE="sustainacore_deploy_stage"
+API_APP="${API_APP:-/opt/sustainacore-ai}"
+SC_IDX_LINK="${SC_IDX_LINK:-/home/opc/Sustainacore}"
+STAGE="${STAGE:-~/sustainacore_deploy_stage}"
+TARGET_SHA="${TARGET_SHA:-$(git rev-parse --verify HEAD)}"
+REPO_URL="${REPO_URL:-$(git remote get-url origin)}"
 
 rsync -az --delete \
   --exclude .git \
@@ -17,41 +20,74 @@ rsync -az --delete \
   -e "ssh -i $SSH_KEY -o StrictHostKeyChecking=accept-new -o IdentitiesOnly=yes" \
   ./ "${VM_USER}@${VM_HOST}:${STAGE}/"
 
-ssh -i "$SSH_KEY" -o StrictHostKeyChecking=accept-new -o IdentitiesOnly=yes \
-  "${VM_USER}@${VM_HOST}" \
-  "APP_DIR='${APP_DIR}' SC_IDX_DIR='${SC_IDX_DIR}' SC_IDX_USER='${SC_IDX_USER}' STAGE='${STAGE}' SQLCLI_BIN='${SQLCLI_BIN:-sql}' bash -s" <<'REMOTE'
-set -euo pipefail
-STAGE_PATH="$HOME/$STAGE"
+ssh -i "$SSH_KEY" -o StrictHostKeyChecking=accept-new -o IdentitiesOnly=yes "${VM_USER}@${VM_HOST}" \
+  TARGET_SHA="$TARGET_SHA" REPO_URL="$REPO_URL" API_APP="$API_APP" SC_IDX_LINK="$SC_IDX_LINK" STAGE="$STAGE" \
+  bash -lc '
+    set -euo pipefail
 
-sync_checkout() {
-  local target_dir="$1"
-  sudo mkdir -p "$target_dir"
-  sudo rsync -a --delete \
-    --exclude .venv \
-    --exclude .env \
-    --exclude wallet \
-    --exclude 'wallet/**' \
-    "$STAGE_PATH"/ "$target_dir"/
-}
+    ensure_sc_idx_release() {
+      local current_target release_root release_dir venv_target
 
-sync_checkout "$APP_DIR"
+      current_target="$(readlink -f "$SC_IDX_LINK" 2>/dev/null || true)"
+      release_root="/opt/sustainacore-sc-idx-${TARGET_SHA:0:12}"
+      release_dir="$release_root"
 
-if [ "$SC_IDX_DIR" != "$APP_DIR" ]; then
-  sync_checkout "$SC_IDX_DIR"
-  if id -u "$SC_IDX_USER" >/dev/null 2>&1; then
-    sudo chown -R "$SC_IDX_USER:$SC_IDX_USER" "$SC_IDX_DIR"
-  fi
-fi
+      if [[ ! -d "$release_dir/.git" ]]; then
+        sudo rm -rf "$release_dir"
+        sudo git clone --no-checkout "$REPO_URL" "$release_dir"
+      fi
 
-cd "$APP_DIR"
-if [ -x scripts/vm_deploy.sh ]; then
-  SQLCLI_BIN="$SQLCLI_BIN" bash scripts/vm_deploy.sh
-fi
-python3 -m venv .venv && source .venv/bin/activate
-pip install -U pip wheel
-[ -f requirements.txt ] && pip install -r requirements.txt || true
-sudo systemctl daemon-reload || true
-sudo systemctl restart sustainacore-ai.service || true
-curl -fsS 'http://127.0.0.1:8080/ask2?q=ping&k=1' | head -c 400
-echo
-REMOTE
+      sudo git -C "$release_dir" fetch --depth 1 origin "$TARGET_SHA"
+      sudo git -C "$release_dir" checkout --detach --force "$TARGET_SHA"
+      sudo chown -R opc:opc "$release_dir"
+
+      venv_target=""
+      if [[ -n "$current_target" && -L "$current_target/.venv" ]]; then
+        venv_target="$(readlink -f "$current_target/.venv" 2>/dev/null || true)"
+      fi
+      if [[ -z "$venv_target" && -L "$API_APP/.venv" ]]; then
+        venv_target="$(readlink -f "$API_APP/.venv" 2>/dev/null || true)"
+      fi
+      if [[ -z "$venv_target" && -d "$API_APP/.venv" ]]; then
+        venv_target="$API_APP/.venv"
+      fi
+      if [[ -n "$venv_target" ]]; then
+        sudo -n -u opc ln -sfn "$venv_target" "$release_dir/.venv"
+      fi
+
+      sudo ln -sfn "$release_dir" "$SC_IDX_LINK"
+      sudo cp "$release_dir"/infra/systemd/sc-idx-*.service /etc/systemd/system/
+      sudo cp "$release_dir"/infra/systemd/sc-idx-*.timer /etc/systemd/system/
+    }
+
+    sudo mkdir -p "$API_APP"
+    sudo rsync -a --delete \
+      --exclude .venv \
+      --exclude .env \
+      --exclude wallet \
+      --exclude "wallet/**" \
+      "$STAGE"/ "$API_APP"/
+
+    cd "$API_APP"
+    if [[ -x scripts/vm_deploy.sh ]]; then
+      SQLCLI_BIN="${SQLCLI_BIN:-sql}" bash scripts/vm_deploy.sh
+    fi
+
+    python3 -m venv .venv
+    source .venv/bin/activate
+    pip install -U pip wheel
+    if [[ -f requirements.txt ]]; then
+      pip install -r requirements.txt || true
+    fi
+
+    ensure_sc_idx_release
+
+    sudo systemctl daemon-reload
+    sudo systemctl reset-failed sc-idx-pipeline.service sc-idx-price-ingest.service sc-idx-completeness-check.service sc-idx-index-calc.service || true
+    sudo systemctl restart sustainacore-ai.service || true
+
+    curl -fsS "http://127.0.0.1:8080/ask2?q=ping&k=1" | head -c 400
+    echo
+    printf "sc_idx_release=%s\n" "$(readlink -f "$SC_IDX_LINK")"
+    sudo -n -u opc git -C "$(readlink -f "$SC_IDX_LINK")" rev-parse --short HEAD
+  '

--- a/ops/scripts/deploy_vm1_git.sh
+++ b/ops/scripts/deploy_vm1_git.sh
@@ -1,49 +1,66 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-APP_DIR=${APP_DIR:-/opt/sustainacore-ai}
-SC_IDX_DIR=${SC_IDX_DIR:-/home/opc/Sustainacore}
+AI_APP_DIR=${AI_APP_DIR:-/opt/sustainacore-ai}
+SC_IDX_LINK=${SC_IDX_LINK:-/home/opc/Sustainacore}
 BRANCH=${BRANCH:-main}
 REMOTE=${REMOTE:-origin}
 
-deploy_checkout() {
-  local target_dir="$1"
-
-  if [ ! -d "$target_dir/.git" ]; then
-    echo "ERROR: $target_dir is not a git checkout."
-    exit 1
-  fi
-
-  cd "$target_dir"
-
-  if [ -n "$(git status --porcelain)" ]; then
-    echo "ERROR: $target_dir has uncommitted changes. Clean the working tree before deploy."
-    exit 1
-  fi
-
-  git fetch "$REMOTE" "$BRANCH"
-  git checkout "$BRANCH"
-  git pull --ff-only "$REMOTE" "$BRANCH"
-
-  if [ -f requirements.txt ]; then
-    python3 -m venv .venv
-    source .venv/bin/activate
-    pip install -U pip wheel
-    pip install -r requirements.txt || true
-  fi
-}
-
-targets=("$APP_DIR")
-if [ "$SC_IDX_DIR" != "$APP_DIR" ]; then
-  targets+=("$SC_IDX_DIR")
+if [[ ! -d "$AI_APP_DIR/.git" ]]; then
+  echo "ERROR: $AI_APP_DIR is not a git checkout."
+  exit 1
 fi
 
-for target_dir in "${targets[@]}"; do
-  deploy_checkout "$target_dir"
-done
+current_sc_idx=$(readlink -f "$SC_IDX_LINK" 2>/dev/null || true)
+if [[ -n "$current_sc_idx" && ! -d "$current_sc_idx/.git" ]]; then
+  echo "ERROR: $current_sc_idx is not a git checkout."
+  exit 1
+fi
 
+cd "$AI_APP_DIR"
+if [[ -n "$(git status --porcelain)" ]]; then
+  echo "ERROR: $AI_APP_DIR has uncommitted changes. Clean the working tree before deploy."
+  exit 1
+fi
+
+git fetch "$REMOTE" "$BRANCH"
+git checkout "$BRANCH"
+git pull --ff-only "$REMOTE" "$BRANCH"
+
+if [[ -f requirements.txt ]]; then
+  python3 -m venv .venv
+  source .venv/bin/activate
+  pip install -U pip wheel
+  pip install -r requirements.txt || true
+fi
+
+repo_url="$(git config --get remote.${REMOTE}.url)"
+target_sha="$(git rev-parse --verify HEAD)"
+release_dir="/opt/sustainacore-sc-idx-${target_sha:0:12}"
+
+if [[ ! -d "$release_dir/.git" ]]; then
+  sudo rm -rf "$release_dir"
+  sudo git clone --no-checkout "$repo_url" "$release_dir"
+fi
+
+sudo git -C "$release_dir" fetch --depth 1 "$REMOTE" "$target_sha"
+sudo git -C "$release_dir" checkout --detach --force "$target_sha"
+sudo chown -R opc:opc "$release_dir"
+
+if [[ -L "$AI_APP_DIR/.venv" ]]; then
+  sudo -n -u opc ln -sfn "$(readlink -f "$AI_APP_DIR/.venv")" "$release_dir/.venv"
+elif [[ -d "$AI_APP_DIR/.venv" ]]; then
+  sudo -n -u opc ln -sfn "$AI_APP_DIR/.venv" "$release_dir/.venv"
+fi
+
+sudo ln -sfn "$release_dir" "$SC_IDX_LINK"
+sudo cp "$release_dir"/infra/systemd/sc-idx-*.service /etc/systemd/system/
+sudo cp "$release_dir"/infra/systemd/sc-idx-*.timer /etc/systemd/system/
 sudo systemctl daemon-reload || true
+sudo systemctl reset-failed sc-idx-pipeline.service sc-idx-price-ingest.service sc-idx-completeness-check.service sc-idx-index-calc.service || true
 sudo systemctl restart sustainacore-ai.service
 
 curl -fsS "http://127.0.0.1:8080/healthz" >/dev/null
-echo "deploy complete"
+printf "deploy complete\n"
+printf "sc_idx_release=%s\n" "$(readlink -f "$SC_IDX_LINK")"
+sudo -n -u opc git -C "$(readlink -f "$SC_IDX_LINK")" rev-parse --short HEAD

--- a/tests/test_pipeline_state.py
+++ b/tests/test_pipeline_state.py
@@ -1,0 +1,122 @@
+import datetime as dt
+import json
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+APP_ROOT = REPO_ROOT / "app"
+for path in (REPO_ROOT, APP_ROOT):
+    if str(path) not in sys.path:
+        sys.path.insert(0, str(path))
+
+import tools.index_engine.pipeline_state as pipeline_state
+
+
+class _FakeCursor:
+    def __init__(self, rows):
+        self._rows = rows
+
+    def execute(self, sql, binds=None):
+        return None
+
+    def fetchall(self):
+        return self._rows
+
+
+class _FakeConnection:
+    def __init__(self, rows):
+        self._rows = rows
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        return False
+
+    def cursor(self):
+        return _FakeCursor(self._rows)
+
+
+def test_compact_details_for_oracle_shrinks_large_context():
+    trading_days = [f"2026-01-{day:02d}" for day in range(1, 32)] * 12
+    details = json.dumps(
+        {
+            "stage": "determine_target_dates",
+            "status": "OK",
+            "detail": "candidate_end=2026-03-27",
+            "detail_json": {
+                "context": {
+                    "calendar_max_date": "2026-03-27",
+                    "candidate_end_date": "2026-03-27",
+                    "trading_days": trading_days,
+                },
+                "counts": {"candidate_end_date": "2026-03-27"},
+                "warnings": [],
+            },
+        }
+    )
+
+    compacted = pipeline_state._compact_details_for_oracle(details)
+
+    assert compacted is not None
+    assert len(compacted) <= pipeline_state.ORACLE_DETAILS_MAX_CHARS
+    assert json.loads(compacted)["stage"] == "determine_target_dates"
+
+
+def test_local_state_resets_when_run_id_changes_same_day(monkeypatch, tmp_path):
+    monkeypatch.setattr(pipeline_state, "_ensure_state_table", lambda: None)
+    monkeypatch.setattr(pipeline_state, "_utc_today", lambda: dt.date(2026, 3, 28))
+
+    store = pipeline_state.PipelineStateStore(state_path=tmp_path / "pipeline_state_latest.json")
+    store._oracle_ok = False
+
+    store.record_stage_end("run-one", "determine_target_dates", "OK", details='{"stage":"determine_target_dates"}')
+    store.record_stage_end("run-two", "preflight_oracle", "OK", details='{"stage":"preflight_oracle"}')
+
+    payload = json.loads((tmp_path / "pipeline_state_latest.json").read_text(encoding="utf-8"))
+
+    assert payload["run_id"] == "run-two"
+    assert sorted(payload["stages"].keys()) == ["preflight_oracle"]
+
+
+def test_fetch_stage_statuses_prefers_local_details_when_oracle_present(monkeypatch, tmp_path):
+    monkeypatch.setattr(pipeline_state, "_ensure_state_table", lambda: None)
+    monkeypatch.setattr(pipeline_state, "_utc_today", lambda: dt.date(2026, 3, 28))
+
+    state_path = tmp_path / "pipeline_state_latest.json"
+    state_path.write_text(
+        json.dumps(
+            {
+                "pipeline_name": "sc_idx_pipeline",
+                "run_date": "2026-03-28",
+                "run_id": "run-local",
+                "stages": {
+                    "determine_target_dates": {
+                        "status": "OK",
+                        "started_at": "2026-03-28T16:44:08+00:00",
+                        "ended_at": "2026-03-28T16:44:09+00:00",
+                        "details": '{"detail":"local"}',
+                    }
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    oracle_rows = [
+        (
+            "determine_target_dates",
+            "OK",
+            dt.datetime(2026, 3, 28, 16, 44, 8, tzinfo=dt.timezone.utc),
+            dt.datetime(2026, 3, 28, 16, 44, 9, tzinfo=dt.timezone.utc),
+            '{"detail":"oracle"}',
+        )
+    ]
+    monkeypatch.setattr(pipeline_state, "get_connection", lambda: _FakeConnection(oracle_rows))
+
+    store = pipeline_state.PipelineStateStore(state_path=state_path)
+    store._oracle_ok = True
+
+    records = store.fetch_stage_statuses("run-local")
+
+    assert records["determine_target_dates"].details == '{"detail":"local"}'

--- a/tests/test_run_pipeline.py
+++ b/tests/test_run_pipeline.py
@@ -97,6 +97,7 @@ def test_smoke_success_writes_report_and_terminal_state(tmp_path):
     assert state["report"]["ended_at"] is not None
     assert state["telemetry"]["ended_at"] is not None
     assert state["report"]["duration_sec"] is not None
+    assert state["report"]["failed_stage"] is None
     assert Path(report_paths["json_path"]).exists()
     assert Path(report_paths["text_path"]).exists()
 

--- a/tests/test_run_pipeline_helpers.py
+++ b/tests/test_run_pipeline_helpers.py
@@ -7,7 +7,13 @@ for path in (REPO_ROOT, APP_ROOT):
     if str(path) not in sys.path:
         sys.path.insert(0, str(path))
 
-from index_engine.orchestration import _derive_terminal_status, _is_oracle_transient_error
+import datetime as dt
+
+from index_engine.orchestration import (
+    _context_trading_days,
+    _derive_terminal_status,
+    _is_oracle_transient_error,
+)
 
 
 def test_is_oracle_transient_error_matches_known_tokens():
@@ -47,3 +53,19 @@ def test_derive_terminal_status_prefers_failed_and_blocked():
     assert _derive_terminal_status(blocked_state) == "blocked"
     assert _derive_terminal_status(degraded_state) == "success_with_degradation"
     assert _derive_terminal_status(skip_state) == "clean_skip"
+
+
+def test_context_trading_days_refetches_when_context_is_compacted(monkeypatch):
+    expected_days = [dt.date(2026, 3, 26), dt.date(2026, 3, 27)]
+    monkeypatch.setattr(
+        "index_engine.orchestration.engine_db.fetch_trading_days",
+        lambda start_date, end_date: expected_days,
+    )
+
+    context = {
+        "calendar_max_date": "2026-03-27",
+        "candidate_end_date": "2026-03-27",
+        "trading_days": {"truncated": True, "count": 200},
+    }
+
+    assert _context_trading_days(context) == expected_days

--- a/tools/index_engine/pipeline_state.py
+++ b/tools/index_engine/pipeline_state.py
@@ -11,6 +11,7 @@ from db_helper import get_connection
 
 PIPELINE_STATE_TABLE = "SC_IDX_PIPELINE_STATE"
 DEFAULT_PIPELINE_NAME = "sc_idx_pipeline"
+ORACLE_DETAILS_MAX_CHARS = 3500
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 DEFAULT_STATE_PATH = REPO_ROOT / "tools" / "audit" / "output" / "pipeline_state_latest.json"
@@ -56,6 +57,60 @@ def _format_iso(value: _dt.datetime | None) -> str | None:
     return value.astimezone(_dt.timezone.utc).isoformat()
 
 
+def _compact_json_value(value: Any) -> Any:
+    if isinstance(value, dict):
+        return {key: _compact_json_value(item) for key, item in value.items()}
+    if isinstance(value, list):
+        compacted = [_compact_json_value(item) for item in value]
+        if len(compacted) <= 20:
+            return compacted
+        if all(not isinstance(item, (dict, list)) for item in compacted):
+            return {
+                "truncated": True,
+                "count": len(compacted),
+                "first": compacted[0],
+                "last": compacted[-1],
+                "sample": compacted[:3],
+            }
+        return {
+            "truncated": True,
+            "count": len(compacted),
+            "head": compacted[:3],
+            "tail": compacted[-2:],
+        }
+    return value
+
+
+def _compact_details_for_oracle(details: str | None) -> str | None:
+    if details is None or len(details) <= ORACLE_DETAILS_MAX_CHARS:
+        return details
+    try:
+        payload = json.loads(details)
+    except Exception:
+        return details[: ORACLE_DETAILS_MAX_CHARS - 3] + "..."
+
+    compacted = _compact_json_value(payload)
+    text = json.dumps(compacted, sort_keys=True, separators=(",", ":"))
+    if len(text) <= ORACLE_DETAILS_MAX_CHARS:
+        return text
+
+    detail_json = compacted.get("detail_json") if isinstance(compacted, dict) else {}
+    context = detail_json.get("context") if isinstance(detail_json, dict) else {}
+    fallback = {
+        "truncated": True,
+        "stage": compacted.get("stage") if isinstance(compacted, dict) else None,
+        "status": compacted.get("status") if isinstance(compacted, dict) else None,
+        "detail": compacted.get("detail") if isinstance(compacted, dict) else None,
+        "error": compacted.get("error") if isinstance(compacted, dict) else None,
+        "error_token": compacted.get("error_token") if isinstance(compacted, dict) else None,
+        "warnings": compacted.get("warnings") if isinstance(compacted, dict) else [],
+        "counts": compacted.get("counts") if isinstance(compacted, dict) else {},
+        "context_keys": sorted(context.keys()) if isinstance(context, dict) else [],
+    }
+    text = json.dumps(fallback, sort_keys=True, separators=(",", ":"))
+    return text[:ORACLE_DETAILS_MAX_CHARS]
+
+
 @dataclass
 class StageRecord:
     status: str
@@ -98,10 +153,53 @@ class PipelineStateStore:
 
     def _ensure_local_run(self, run_id: str, run_date: _dt.date) -> Dict[str, Any]:
         payload = self._load_local_state()
-        if payload.get("pipeline_name") != self.pipeline_name or payload.get("run_date") != run_date.isoformat():
+        if (
+            payload.get("pipeline_name") != self.pipeline_name
+            or payload.get("run_date") != run_date.isoformat()
+            or payload.get("run_id") != run_id
+        ):
             payload = {"pipeline_name": self.pipeline_name, "run_date": run_date.isoformat(), "run_id": run_id}
         payload.setdefault("stages", {})
         return payload
+
+    def _load_local_stage_statuses(self, run_id: str) -> Dict[str, StageRecord]:
+        payload = self._load_local_state()
+        if payload.get("pipeline_name") != self.pipeline_name or payload.get("run_id") != run_id:
+            return {}
+        local_stages = payload.get("stages", {})
+        return {
+            str(name): StageRecord(
+                status=str(entry.get("status")),
+                started_at=_dt.datetime.fromisoformat(entry["started_at"]) if entry.get("started_at") else None,
+                ended_at=_dt.datetime.fromisoformat(entry["ended_at"]) if entry.get("ended_at") else None,
+                details=entry.get("details"),
+            )
+            for name, entry in local_stages.items()
+        }
+
+    def _write_local_stage(
+        self,
+        run_id: str,
+        stage_name: str,
+        *,
+        status: str,
+        details: str | None,
+        ended: bool,
+    ) -> None:
+        run_date = _utc_today()
+        payload = self._ensure_local_run(run_id, run_date)
+        entry = payload["stages"].get(stage_name, {})
+        entry.update(
+            {
+                "status": status,
+                "started_at": entry.get("started_at")
+                or _format_iso(_dt.datetime.now(_dt.timezone.utc)),
+                "ended_at": _format_iso(_dt.datetime.now(_dt.timezone.utc)) if ended else None,
+                "details": details,
+            }
+        )
+        payload["stages"][stage_name] = entry
+        self._write_local_state(payload)
 
     def create_run_id(self) -> str:
         return str(uuid.uuid4())
@@ -133,7 +231,7 @@ class PipelineStateStore:
         return payload.get("run_id")
 
     def fetch_stage_statuses(self, run_id: str) -> Dict[str, StageRecord]:
-        stages: Dict[str, StageRecord] = {}
+        stages: Dict[str, StageRecord] = self._load_local_stage_statuses(run_id)
         if self._oracle_ok:
             sql = (
                 "SELECT stage_name, stage_status, started_at, ended_at, details "
@@ -146,27 +244,28 @@ class PipelineStateStore:
                     cur = conn.cursor()
                     cur.execute(sql, {"run_id": run_id, "pipeline_name": self.pipeline_name})
                     for stage_name, status, started_at, ended_at, details in cur.fetchall():
-                        stages[str(stage_name)] = StageRecord(
-                            status=str(status),
-                            started_at=started_at,
-                            ended_at=ended_at,
-                            details=str(details) if details else None,
+                        stages.setdefault(
+                            str(stage_name),
+                            StageRecord(
+                                status=str(status),
+                                started_at=started_at,
+                                ended_at=ended_at,
+                                details=str(details) if details else None,
+                            ),
                         )
                 return stages
             except Exception:
                 self._oracle_ok = False
-        payload = self._load_local_state()
-        local_stages = payload.get("stages", {})
-        for name, entry in local_stages.items():
-            stages[name] = StageRecord(
-                status=str(entry.get("status")),
-                started_at=_dt.datetime.fromisoformat(entry["started_at"]) if entry.get("started_at") else None,
-                ended_at=_dt.datetime.fromisoformat(entry["ended_at"]) if entry.get("ended_at") else None,
-                details=entry.get("details"),
-            )
         return stages
 
     def record_stage_start(self, run_id: str, stage_name: str, details: str | None = None) -> None:
+        self._write_local_stage(
+            run_id,
+            stage_name,
+            status="STARTED",
+            details=details,
+            ended=False,
+        )
         if self._oracle_ok:
             sql = (
                 "MERGE INTO SC_IDX_PIPELINE_STATE dst "
@@ -191,24 +290,21 @@ class PipelineStateStore:
                             "run_id": run_id,
                             "pipeline_name": self.pipeline_name,
                             "stage_name": stage_name,
-                            "details": details,
+                            "details": _compact_details_for_oracle(details),
                         },
                     )
                     conn.commit()
-                    return
             except Exception:
                 self._oracle_ok = False
-        run_date = _utc_today()
-        payload = self._ensure_local_run(run_id, run_date)
-        payload["stages"][stage_name] = {
-            "status": "STARTED",
-            "started_at": _format_iso(_dt.datetime.now(_dt.timezone.utc)),
-            "ended_at": None,
-            "details": details,
-        }
-        self._write_local_state(payload)
 
     def record_stage_end(self, run_id: str, stage_name: str, status: str, details: str | None = None) -> None:
+        self._write_local_stage(
+            run_id,
+            stage_name,
+            status=status,
+            details=details,
+            ended=True,
+        )
         if self._oracle_ok:
             sql = (
                 "UPDATE SC_IDX_PIPELINE_STATE "
@@ -227,24 +323,9 @@ class PipelineStateStore:
                             "run_id": run_id,
                             "stage_name": stage_name,
                             "status": status,
-                            "details": details,
+                            "details": _compact_details_for_oracle(details),
                         },
                     )
                     conn.commit()
-                    return
             except Exception:
                 self._oracle_ok = False
-        run_date = _utc_today()
-        payload = self._ensure_local_run(run_id, run_date)
-        entry = payload["stages"].get(stage_name, {})
-        entry.update(
-            {
-                "status": status,
-                "started_at": entry.get("started_at")
-                or _format_iso(_dt.datetime.now(_dt.timezone.utc)),
-                "ended_at": _format_iso(_dt.datetime.now(_dt.timezone.utc)),
-                "details": details,
-            }
-        )
-        payload["stages"][stage_name] = entry
-        self._write_local_state(payload)


### PR DESCRIPTION
## Summary
- harden SC_IDX pipeline state persistence after the March 28 VM1 recovery
- keep Oracle `SC_IDX_PIPELINE_STATE` rows compact so large stage payloads do not get stranded at `STARTED`
- keep the full same-run stage payload in the repo-local state file and key that file by `run_id`

## Changes
- compact oversized stage `details` before writing them to Oracle in `tools/index_engine/pipeline_state.py`
- always write the full local pipeline state file and reset it when the `run_id` changes on the same UTC day
- prefer same-run local stage records when resuming, with Oracle rows still available for compact status visibility
- rehydrate trading days from Oracle when a resumed context contains compacted stage payloads instead of the full list
- document the compact-Oracle/full-local state model in `AGENTS.md`, `docs/index_engine_langgraph_orchestration.md`, and `docs/runbooks/pipeline_scheduler.md`
- add regression coverage for oversized stage payloads, same-day local-state mixing, and compacted trading-day resume behavior
- add the minimal cspell ignore terms needed for the touched operational docs

## Testing
- `cd /tmp/sustainacore-scidx-self-overlap && . /mnt/c/codex/Sustainacore/.venv/bin/activate && pytest -q tests/test_pipeline_state.py tests/test_run_pipeline.py tests/test_run_pipeline_helpers.py`
- `cd /tmp/sustainacore-scidx-self-overlap && python3 -m py_compile tools/index_engine/pipeline_state.py app/index_engine/orchestration.py`
- `ssh vm1-bot 'sudo systemd-run --wait --pipe --collect --service-type=exec --property User=opc --property WorkingDirectory=/home/opc/Sustainacore --property Environment=PYTHONPATH=/home/opc/Sustainacore --property Environment=PYTHONUNBUFFERED=1 --property Environment=TNS_ADMIN=/opt/adb_wallet --property EnvironmentFile=/etc/sustainacore/db.env --property EnvironmentFile=/etc/sustainacore/index.env --property EnvironmentFile=/etc/sustainacore-ai/secrets.env --property RuntimeMaxSec=900 /home/opc/Sustainacore/.venv/bin/python /home/opc/Sustainacore/tools/index_engine/run_pipeline.py --restart'`

## Evidence
- CI: SC_IDX orchestration https://github.com/joaotovolli/Sustainacore/actions/runs/23690119681/job/69016171119
- CI: Canary on VM https://github.com/joaotovolli/Sustainacore/actions/runs/23690119703/job/69016187915
- live scheduler checkout before this follow-up hardening: `/opt/sustainacore-sc-idx-33bb72492e20` at `33bb724`
- live scheduler checkout after this deploy: `/opt/sustainacore-sc-idx-aeb6332f3296` at `aeb6332`
- production recovery run that advanced TECH100 to March 27: `661485c4-6577-4d09-81c7-9ae808b567a9` (`OK`)
- post-deploy verification run on the hardened checkout: `a36fa4ad-43e1-4736-a11a-a48bf0abe217` (`OK`)
- live Oracle max dates after recovery: `SC_IDX_TRADING_DAYS=2026-03-27`, `SC_IDX_PRICES_CANON=2026-03-27`, `SC_IDX_LEVELS=2026-03-27`, `SC_IDX_STATS_DAILY=2026-03-27`, `SC_IDX_PORTFOLIO_ANALYTICS_DAILY=2026-03-27`, `SC_IDX_PORTFOLIO_POSITION_DAILY=2026-03-27`
- root cause for the remaining operational blind spot: `determine_target_dates` was persisting a large `trading_days` list; Oracle stage rows would stop at `STARTED` when `DETAILS VARCHAR2(4000)` overflowed, and the repo-local fallback file could then merge multiple same-day runs because it was keyed only by day
- post-deploy proof that the overflow path is fixed: Oracle `SC_IDX_PIPELINE_STATE` for run `a36fa4ad-43e1-4736-a11a-a48bf0abe217` shows `determine_target_dates` with `stage_status=OK`, `ended_at` populated, and `details_len=1392`
- post-deploy proof that same-day fallback mixing is fixed: `/home/opc/Sustainacore/tools/audit/output/pipeline_state_latest.json` now carries `run_id=a36fa4ad-43e1-4736-a11a-a48bf0abe217`

## Notes / Follow-ups
- production is already hotfixed on VM1 with commit `aeb6332` because the incident was live; merge this PR to bring `main` back in sync with the deployed scheduler checkout
- the underlying one-day lag incident is resolved: on Saturday, March 28, 2026, the next valid target date remained Friday, March 27, 2026, and the index is now fresh through that date
- this PR does not introduce a new orchestration path; it hardens the existing LangGraph-centered process and operator visibility
