### PR TITLE
[codex] Fix SC_IDX scheduler self-locking

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -230,9 +230,14 @@ dmesg -T | egrep -i "oom|out of memory|killed process" | tail -n 60
 - Primary systemd scheduler: `sc-idx-pipeline.timer` -> `sc-idx-pipeline.service`.
 - The live scheduler path is `/home/opc/Sustainacore`; it should resolve to a versioned release checkout under `/opt/sustainacore-sc-idx-*`.
 - Always prove the active scheduler revision with `readlink -f /home/opc/Sustainacore` and `git -C "$(readlink -f /home/opc/Sustainacore)" rev-parse --short HEAD`.
+- `sc-idx-pipeline.service` must invoke `run_pipeline.py` directly. Do not wrap that unit in
+  `flock`; the LangGraph runtime owns `/tmp/sc_idx_pipeline.lock` internally, and an outer
+  service-level `flock` will self-block the scheduler path.
 - Pipeline state is tracked in `SC_IDX_PIPELINE_STATE`; `python3 tools/index_engine/run_pipeline.py` resumes safe completed nodes by default.
 - Resume is only for incomplete runs. If a run already reached `persist_terminal_status` or `release_lock`, the next invocation must start a new `run_id` instead of mutating the old terminal row.
 - `acquire_lock` is a terminal gate. If lock acquisition is `BLOCKED`, the graph must branch directly to report/alert/telemetry and must not continue into `determine_target_dates`.
+- Early blocked/failed reports should still surface last-known calendar and table freshness from the
+  Oracle health snapshot whenever preflight succeeded.
 - Oracle stage-state rows are intentionally compact; the full same-run stage payload also lives in
   `tools/audit/output/pipeline_state_latest.json` and is keyed by `run_id`, not only by day.
 - Force a full restart with `python3 tools/index_engine/run_pipeline.py --restart`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -231,6 +231,8 @@ dmesg -T | egrep -i "oom|out of memory|killed process" | tail -n 60
 - The live scheduler path is `/home/opc/Sustainacore`; it should resolve to a versioned release checkout under `/opt/sustainacore-sc-idx-*`.
 - Always prove the active scheduler revision with `readlink -f /home/opc/Sustainacore` and `git -C "$(readlink -f /home/opc/Sustainacore)" rev-parse --short HEAD`.
 - Pipeline state is tracked in `SC_IDX_PIPELINE_STATE`; `python3 tools/index_engine/run_pipeline.py` resumes safe completed nodes by default.
+- Resume is only for incomplete runs. If a run already reached `persist_terminal_status` or `release_lock`, the next invocation must start a new `run_id` instead of mutating the old terminal row.
+- `acquire_lock` is a terminal gate. If lock acquisition is `BLOCKED`, the graph must branch directly to report/alert/telemetry and must not continue into `determine_target_dates`.
 - Oracle stage-state rows are intentionally compact; the full same-run stage payload also lives in
   `tools/audit/output/pipeline_state_latest.json` and is keyed by `run_id`, not only by day.
 - Force a full restart with `python3 tools/index_engine/run_pipeline.py --restart`.

--- a/app/index_engine/orchestration.py
+++ b/app/index_engine/orchestration.py
@@ -1755,6 +1755,62 @@ def _make_stage_node(stage_name: str, runtime: PipelineRuntime):
     return _node
 
 
+def _set_context_default(context: dict[str, Any], key: str, value: Any) -> None:
+    if value in {None, ""}:
+        return
+    existing = context.get(key)
+    if existing in {None, ""}:
+        context[key] = value
+
+
+def _hydrate_report_context_with_health_snapshot(
+    state: PipelineGraphState,
+    context: dict[str, Any],
+) -> tuple[dict[str, Any], list[str]]:
+    terminal_status = _derive_terminal_status(state)
+    preflight_status = ((state.get("stage_results") or {}).get("preflight_oracle") or {}).get("status")
+    if terminal_status not in {"failed", "blocked", "clean_skip"} or preflight_status != "OK":
+        return context, []
+
+    needs_snapshot = any(
+        context.get(key) in {None, ""}
+        for key in (
+            "calendar_max_date",
+            "max_canon_before",
+            "max_level_before",
+            "max_portfolio_before",
+            "portfolio_position_max_after",
+        )
+    )
+    if not needs_snapshot:
+        return context, []
+
+    try:
+        health = collect_health_snapshot(
+            stage_durations={
+                stage_name: float((result or {}).get("duration_sec") or 0.0)
+                for stage_name, result in (state.get("stage_results") or {}).items()
+                if isinstance(result, dict)
+            },
+            last_error=_report_root_cause(state),
+        )
+    except Exception as exc:
+        return context, [f"report_health_snapshot_failed:{exc}"]
+
+    enriched = dict(context)
+    _set_context_default(enriched, "calendar_max_date", health.get("calendar_max_date"))
+    _set_context_default(enriched, "expected_target_date", health.get("calendar_max_date"))
+    _set_context_default(enriched, "expected_target_source", "calendar_snapshot")
+    _set_context_default(enriched, "max_canon_before", health.get("canon_max_date"))
+    _set_context_default(enriched, "max_level_before", health.get("levels_max_date"))
+    _set_context_default(enriched, "stats_max_after", health.get("stats_max_date"))
+    _set_context_default(enriched, "max_portfolio_before", health.get("portfolio_max_date"))
+    _set_context_default(enriched, "portfolio_position_max_after", health.get("portfolio_position_max_date"))
+    _set_context_default(enriched, "repo_root", health.get("repo_root"))
+    _set_context_default(enriched, "repo_head", health.get("repo_head"))
+    return enriched, []
+
+
 def _generate_run_report(state: PipelineGraphState, runtime: PipelineRuntime) -> PipelineGraphState:
     next_state = _refresh_pipeline_report(dict(state), runtime)
     report_paths = (next_state.get("context") or {}).get("report_paths") or {}
@@ -1779,7 +1835,12 @@ def _refresh_pipeline_report(state: PipelineGraphState, runtime: PipelineRuntime
     next_state: PipelineGraphState = dict(state)
     terminal_status = _derive_terminal_status(next_state)
     next_state["terminal_status"] = terminal_status
-    report_context = dict(next_state.get("context") or {})
+    report_context, snapshot_warnings = _hydrate_report_context_with_health_snapshot(
+        next_state,
+        dict(next_state.get("context") or {}),
+    )
+    for warning in snapshot_warnings:
+        _append_warning(next_state, warning)
     summary = build_pipeline_run_summary(
         run_id=next_state["run_id"],
         terminal_status=terminal_status,

--- a/app/index_engine/orchestration.py
+++ b/app/index_engine/orchestration.py
@@ -2084,6 +2084,13 @@ def _route_after_preflight(state: PipelineGraphState) -> str:
     return "acquire_lock"
 
 
+def _route_after_acquire_lock(state: PipelineGraphState) -> str:
+    terminal = _derive_terminal_status(state)
+    if terminal in {"failed", "blocked"}:
+        return "generate_run_report"
+    return "determine_target_dates"
+
+
 def _route_after_determine(state: PipelineGraphState) -> str:
     terminal = _derive_terminal_status(state)
     if terminal in {"clean_skip", "failed", "blocked"}:
@@ -2155,7 +2162,7 @@ def build_pipeline_graph(runtime: PipelineRuntime):
 
     graph.add_edge(START, "preflight_oracle")
     graph.add_conditional_edges("preflight_oracle", _route_after_preflight)
-    graph.add_edge("acquire_lock", "determine_target_dates")
+    graph.add_conditional_edges("acquire_lock", _route_after_acquire_lock)
     graph.add_conditional_edges("determine_target_dates", _route_after_determine)
     graph.add_conditional_edges("readiness_probe", _route_after_readiness)
     graph.add_conditional_edges("ingest_prices", _route_after_ingest)

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -110,6 +110,10 @@
   - bounded retries
   - bounded readiness fallbacks
   - repo-native JSON artifacts plus Oracle-backed stage state
+- Only incomplete runs should resume. Once a run reaches `persist_terminal_status` or
+  `release_lock`, the next invocation must start a fresh `run_id`.
+- `acquire_lock` is a hard gate. A blocked lock result must branch directly to reporting and
+  terminal persistence, not continue into target-date planning.
 - Run artifacts:
   - reports: `tools/audit/output/pipeline_runs/`
   - telemetry: `tools/audit/output/pipeline_telemetry/`

--- a/docs/index_engine_langgraph_orchestration.md
+++ b/docs/index_engine_langgraph_orchestration.md
@@ -24,6 +24,9 @@ no Celery, no watch loops, and no unbounded retries.
 - Primary VM1 timer/service: `infra/systemd/sc-idx-pipeline.timer` -> `infra/systemd/sc-idx-pipeline.service`
 
 The CLI remains the operator entrypoint. Internally it now builds and executes a LangGraph state graph.
+The pipeline service must invoke that CLI directly. Do not add an outer `flock` to
+`sc-idx-pipeline.service`; the graph acquires `/tmp/sc_idx_pipeline.lock` itself, and a
+service-level `flock` will self-block the timer path.
 
 ## Graph shape
 
@@ -130,6 +133,7 @@ The report includes:
 - SMTP delivery state and message ID when email is attempted
 - stale signals and freshness lag by key table
 - deployed `repo_root` and `repo_head`
+- best-effort last-known freshness even for early blocked/failure exits after Oracle preflight
 - root cause token
 - next remediation step
 

--- a/docs/index_engine_langgraph_orchestration.md
+++ b/docs/index_engine_langgraph_orchestration.md
@@ -47,6 +47,8 @@ The current graph executes these nodes in order, with conditional terminal branc
 Important routing behavior:
 
 - `preflight_oracle` can end the run as `failed` or `blocked`
+- `acquire_lock` is a hard gate; if the shared lock is busy, the graph must branch directly to
+  `generate_run_report` instead of continuing into target-date planning
 - `determine_target_dates` can end the run as `clean_skip` for `up_to_date` or `daily_budget_stop`
 - `readiness_probe` can end the run as `clean_skip` for `provider_not_ready`
 - `completeness_check` can degrade into `imputation_or_replacement` instead of failing immediately
@@ -65,6 +67,8 @@ LangGraph is the orchestrator, but the durability layer is repo-native and Oracl
   - Oracle rows keep compact JSON details so node state does not overflow `VARCHAR2(4000)`
   - the full same-run payload is also written to `tools/audit/output/pipeline_state_latest.json`
     and is keyed by `run_id`, not just by UTC day
+  - only incomplete runs are resumable; once a run reaches `persist_terminal_status` or
+    `release_lock`, the next invocation must create a new `run_id`
 - `SC_IDX_JOB_RUNS`
   - run-level summary row
   - short terminal codes: `OK`, `DEGRADED`, `SKIP`, `ERROR`, `BLOCKED`

--- a/docs/index_engine_verify.md
+++ b/docs/index_engine_verify.md
@@ -116,6 +116,10 @@ Expected signals:
 - latest report exists in `tools/audit/output/pipeline_runs/`
 - latest telemetry snapshot exists in `tools/audit/output/pipeline_telemetry/`
 - latest report/health artifacts show the active `repo_root` and `repo_head`
+- if the run is `BLOCKED` at `acquire_lock`, there should be no newly executed
+  `determine_target_dates` stage for that `run_id`
+- a new invocation after a terminal `BLOCKED` or `FAILED` run should create a new `run_id`; only
+  incomplete runs should resume
 - `expected_target_date` and `latest_complete_date` do not show an unexpected lag
 - `SC_IDX_PORTFOLIO_ANALYTICS_DAILY` and `SC_IDX_PORTFOLIO_POSITION_DAILY` max dates match the latest `SC_IDX_LEVELS` trade date
 

--- a/docs/index_engine_verify.md
+++ b/docs/index_engine_verify.md
@@ -120,7 +120,8 @@ Expected signals:
   `determine_target_dates` stage for that `run_id`
 - a new invocation after a terminal `BLOCKED` or `FAILED` run should create a new `run_id`; only
   incomplete runs should resume
-- `expected_target_date` and `latest_complete_date` do not show an unexpected lag
+- even an early blocked run should still show last-known `expected_target_date`,
+  `latest_complete_date`, and key table max dates when Oracle preflight succeeded
 - `SC_IDX_PORTFOLIO_ANALYTICS_DAILY` and `SC_IDX_PORTFOLIO_POSITION_DAILY` max dates match the latest `SC_IDX_LEVELS` trade date
 
 ### 7. Scheduler checks
@@ -142,6 +143,7 @@ Expected result:
 
 - `sc-idx-pipeline.timer` is present and scheduled
 - `sc-idx-pipeline.service` is the primary VM1 orchestration service
+- `systemctl show sc-idx-pipeline.service -p ExecStart` does not include `/usr/bin/flock`
 - `sc-telemetry-report.timer` is present and scheduled
 - `sc-telemetry-report.service` points to `tools/index_engine/daily_telemetry_report.py --send`
 

--- a/docs/runbooks/pipeline_scheduler.md
+++ b/docs/runbooks/pipeline_scheduler.md
@@ -65,6 +65,10 @@ Do not print env contents in logs or docs.
 - primary pipeline runtime limit: `RuntimeMaxSec=3600`
 - ingest runtime limit: `RuntimeMaxSec=7200`
 - terminal blocked/guard exits use code `2` and should not be auto-restarted by systemd
+- a blocked `acquire_lock` outcome is terminal for that invocation; the graph must report and exit
+  before `determine_target_dates`
+- only incomplete runs should resume; once a run reaches `persist_terminal_status` or
+  `release_lock`, the next invocation must create a fresh `run_id`
 - restart storm guardrails remain in the units through `StartLimit*`
 - retries inside the graph are bounded and stage-specific
 
@@ -137,8 +141,11 @@ sudo systemctl start sc-telemetry-report.service
 ```
 
 If repeated `BLOCKED` runs happen with no active SC_IDX process, inspect the effective unit config
-and verify exit code `2` is listed under `SuccessExitStatus` / `RestartPreventExitStatus` before
-rerunning the pipeline.
+and verify both of these before rerunning the pipeline:
+
+- exit code `2` is listed under `SuccessExitStatus` / `RestartPreventExitStatus`
+- the installed graph does not continue past `acquire_lock`, and same-day blocked reruns are not
+  mutating a single terminal `run_id`
 
 ## Alert behavior
 

--- a/docs/runbooks/pipeline_scheduler.md
+++ b/docs/runbooks/pipeline_scheduler.md
@@ -61,7 +61,11 @@ Do not print env contents in logs or docs.
 
 ## Lock and runtime guardrails
 
-- ingest + pipeline use the shared lock `/tmp/sc_idx_pipeline.lock` via `flock -n`
+- the pipeline runtime owns `/tmp/sc_idx_pipeline.lock` internally inside `run_pipeline.py`
+- `sc-idx-pipeline.service` must run the Python entrypoint directly and must not wrap it in
+  `flock`, or the timer path will self-block before LangGraph can progress
+- compatibility ingest/completeness/calc units still use `flock -n /tmp/sc_idx_pipeline.lock`
+  because they are separate entrypoints
 - primary pipeline runtime limit: `RuntimeMaxSec=3600`
 - ingest runtime limit: `RuntimeMaxSec=7200`
 - terminal blocked/guard exits use code `2` and should not be auto-restarted by systemd
@@ -144,6 +148,7 @@ If repeated `BLOCKED` runs happen with no active SC_IDX process, inspect the eff
 and verify both of these before rerunning the pipeline:
 
 - exit code `2` is listed under `SuccessExitStatus` / `RestartPreventExitStatus`
+- `systemctl show sc-idx-pipeline.service -p ExecStart` does not include `/usr/bin/flock`
 - the installed graph does not continue past `acquire_lock`, and same-day blocked reruns are not
   mutating a single terminal `run_id`
 
@@ -178,6 +183,8 @@ and verify both of these before rerunning the pipeline:
 - safe retry: `sudo systemctl restart sc-idx-pipeline.service`
 - if Oracle preflight blocks, fix wallet/env access first, then rerun
 - if the pipeline returns `BLOCKED` because the lock is busy, wait for the active run to conclude
+- if the pipeline returns `BLOCKED` immediately from the timer path and `ExecStart` still includes
+  `flock`, fix the installed unit before rerunning; that is a self-deadlock, not a real concurrent run
 - do not delete `SC_IDX_PIPELINE_STATE` unless following an explicit emergency recovery procedure
 
 ## Update workflow

--- a/infra/systemd/README.md
+++ b/infra/systemd/README.md
@@ -32,6 +32,8 @@ Units live under `infra/systemd/`:
 - Writes telemetry under `tools/audit/output/pipeline_telemetry/`.
 - Writes health snapshots under `tools/audit/output/pipeline_health_latest.txt`, including
   `repo_root`, `repo_head`, freshness dates, and `last_error`.
+- The pipeline service must not wrap the CLI in `flock`; `run_pipeline.py` owns
+  `/tmp/sc_idx_pipeline.lock` internally and writes blocked/report/telemetry state itself.
 - Treats exit code `2` as a terminal blocked/non-advancing outcome so systemd does not auto-restart into the same lock.
 - Timer schedule: **00:30, 05:30, 09:30, 13:30 UTC** with `Persistent=true`.
 

--- a/infra/systemd/sc-idx-pipeline.service
+++ b/infra/systemd/sc-idx-pipeline.service
@@ -23,7 +23,10 @@ ExecStartPre=/bin/ls -l /etc/sustainacore/db.env /etc/sustainacore/index.env /et
 ExecStartPre=/usr/bin/namei -l /etc/sustainacore/db.env
 ExecStartPre=/usr/bin/namei -l /etc/sustainacore/index.env
 ExecStartPre=/usr/bin/namei -l /etc/sustainacore-ai/secrets.env
-ExecStart=/usr/bin/flock -n /tmp/sc_idx_pipeline.lock /home/opc/Sustainacore/.venv/bin/python /home/opc/Sustainacore/tools/index_engine/run_pipeline.py
+# run_pipeline.py acquires /tmp/sc_idx_pipeline.lock internally. Wrapping the
+# service in flock self-blocks the scheduler path and prevents the timer run
+# from ever advancing beyond acquire_lock.
+ExecStart=/home/opc/Sustainacore/.venv/bin/python /home/opc/Sustainacore/tools/index_engine/run_pipeline.py
 SuccessExitStatus=2
 RestartPreventExitStatus=2
 Restart=on-failure

--- a/tests/test_pipeline_state.py
+++ b/tests/test_pipeline_state.py
@@ -22,6 +22,9 @@ class _FakeCursor:
     def fetchall(self):
         return self._rows
 
+    def fetchone(self):
+        return self._rows[0] if self._rows else None
+
 
 class _FakeConnection:
     def __init__(self, rows):
@@ -120,3 +123,71 @@ def test_fetch_stage_statuses_prefers_local_details_when_oracle_present(monkeypa
     records = store.fetch_stage_statuses("run-local")
 
     assert records["determine_target_dates"].details == '{"detail":"local"}'
+
+
+def test_fetch_resume_run_id_skips_terminal_local_run(monkeypatch, tmp_path):
+    monkeypatch.setattr(pipeline_state, "_ensure_state_table", lambda: None)
+    monkeypatch.setattr(pipeline_state, "_utc_today", lambda: dt.date(2026, 3, 31))
+
+    state_path = tmp_path / "pipeline_state_latest.json"
+    state_path.write_text(
+        json.dumps(
+            {
+                "pipeline_name": "sc_idx_pipeline",
+                "run_date": "2026-03-31",
+                "run_id": "run-terminal",
+                "stages": {
+                    "acquire_lock": {
+                        "status": "BLOCKED",
+                        "started_at": "2026-03-31T00:30:15+00:00",
+                        "ended_at": "2026-03-31T00:30:15+00:00",
+                        "details": '{"detail":"lock_busy"}',
+                    },
+                    "persist_terminal_status": {
+                        "status": "OK",
+                        "started_at": "2026-03-31T00:30:18+00:00",
+                        "ended_at": "2026-03-31T00:30:18+00:00",
+                        "details": '{"detail":"terminal_status=blocked"}',
+                    },
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    store = pipeline_state.PipelineStateStore(state_path=state_path)
+    store._oracle_ok = False
+
+    assert store.fetch_resume_run_id(run_date=dt.date(2026, 3, 31)) is None
+
+
+def test_fetch_resume_run_id_ignores_terminal_oracle_run(monkeypatch, tmp_path):
+    monkeypatch.setattr(pipeline_state, "_ensure_state_table", lambda: None)
+    monkeypatch.setattr(pipeline_state, "_utc_today", lambda: dt.date(2026, 3, 31))
+
+    oracle_rows = [
+        (
+            "run-terminal",
+            "persist_terminal_status",
+            "OK",
+            dt.datetime(2026, 3, 31, 13, 30, 20, tzinfo=dt.timezone.utc),
+        ),
+        (
+            "run-terminal",
+            "acquire_lock",
+            "BLOCKED",
+            dt.datetime(2026, 3, 31, 13, 30, 19, tzinfo=dt.timezone.utc),
+        ),
+        (
+            "run-incomplete",
+            "determine_target_dates",
+            "OK",
+            dt.datetime(2026, 3, 31, 14, 0, 0, tzinfo=dt.timezone.utc),
+        ),
+    ]
+    monkeypatch.setattr(pipeline_state, "get_connection", lambda: _FakeConnection(oracle_rows))
+
+    store = pipeline_state.PipelineStateStore(state_path=tmp_path / "pipeline_state_latest.json")
+    store._oracle_ok = True
+
+    assert store.fetch_resume_run_id(run_date=dt.date(2026, 3, 31)) == "run-incomplete"

--- a/tests/test_run_pipeline.py
+++ b/tests/test_run_pipeline.py
@@ -21,6 +21,7 @@ from index_engine.orchestration import (
     build_pipeline_graph,
     run_pipeline,
 )
+import index_engine.orchestration as orchestration
 import tools.index_engine.run_pipeline as pipeline_cli
 
 
@@ -222,6 +223,51 @@ def test_blocked_acquire_lock_short_circuits_before_determine(tmp_path):
     assert final_state["terminal_status"] == "blocked"
     assert final_state["stage_results"]["acquire_lock"]["status"] == "BLOCKED"
     assert "determine_target_dates" not in final_state["stage_results"]
+
+
+def test_blocked_acquire_lock_uses_health_snapshot_for_freshness(tmp_path, monkeypatch):
+    class LockBlockedRuntime(SmokePipelineRuntime):
+        def __init__(self):
+            super().__init__(
+                smoke_scenario="success",
+                report_dir=tmp_path,
+                state_store=_FakeStore(),
+            )
+
+        def acquire_lock(self, state):
+            return {
+                "status": "BLOCKED",
+                "detail": "lock_busy:/tmp/sc_idx_pipeline.lock",
+                "error": "another sc_idx_pipeline run is active",
+                "error_token": "lock_busy",
+                "remediation": "Wait for the active run to conclude, then rerun the pipeline once.",
+            }
+
+    monkeypatch.setattr(
+        orchestration,
+        "collect_health_snapshot",
+        lambda **_: {
+            "calendar_max_date": "2026-01-08",
+            "canon_max_date": "2026-01-05",
+            "levels_max_date": "2026-01-05",
+            "stats_max_date": "2026-01-05",
+            "portfolio_max_date": "2026-01-05",
+            "portfolio_position_max_date": "2026-01-05",
+            "repo_root": "/repo",
+            "repo_head": "abc1234",
+        },
+    )
+
+    runtime = LockBlockedRuntime()
+    graph = build_pipeline_graph(runtime)
+    final_state = graph.invoke(_state())
+
+    report = final_state["report"]
+    assert report["freshness"]["expected_target_date"] == "2026-01-08"
+    assert report["freshness"]["levels_max_date"] == "2026-01-05"
+    assert report["freshness"]["health"]["verdict"] == "stale"
+    assert report["operational_state"]["lock_contention"] is True
+    assert report["runtime_identity"]["repo_head"] == "abc1234"
 
 
 def test_graph_runs_portfolio_stage_before_report(tmp_path):

--- a/tests/test_run_pipeline.py
+++ b/tests/test_run_pipeline.py
@@ -191,6 +191,39 @@ def test_resume_skips_completed_stage(tmp_path):
     assert final_state["terminal_status"] == "success"
 
 
+def test_blocked_acquire_lock_short_circuits_before_determine(tmp_path):
+    class LockBlockedRuntime(SmokePipelineRuntime):
+        def __init__(self):
+            super().__init__(
+                smoke_scenario="success",
+                report_dir=tmp_path,
+                state_store=_FakeStore(),
+            )
+            self.determine_calls = 0
+
+        def acquire_lock(self, state):
+            return {
+                "status": "BLOCKED",
+                "detail": "lock_busy:/tmp/sc_idx_pipeline.lock",
+                "error": "another sc_idx_pipeline run is active",
+                "error_token": "lock_busy",
+                "remediation": "Wait for the active run to conclude, then rerun the pipeline once.",
+            }
+
+        def determine_target_dates(self, state):
+            self.determine_calls += 1
+            return super().determine_target_dates(state)
+
+    runtime = LockBlockedRuntime()
+    graph = build_pipeline_graph(runtime)
+    final_state = graph.invoke(_state())
+
+    assert runtime.determine_calls == 0
+    assert final_state["terminal_status"] == "blocked"
+    assert final_state["stage_results"]["acquire_lock"]["status"] == "BLOCKED"
+    assert "determine_target_dates" not in final_state["stage_results"]
+
+
 def test_graph_runs_portfolio_stage_before_report(tmp_path):
     class PortfolioRuntime(SmokePipelineRuntime):
         def __init__(self):

--- a/tests/test_systemd_units.py
+++ b/tests/test_systemd_units.py
@@ -1,0 +1,12 @@
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+def test_sc_idx_pipeline_service_uses_internal_lock_only():
+    unit_text = (REPO_ROOT / "infra/systemd/sc-idx-pipeline.service").read_text(encoding="utf-8")
+
+    assert "tools/index_engine/run_pipeline.py" in unit_text
+    assert "ExecStart=/usr/bin/flock -n /tmp/sc_idx_pipeline.lock" not in unit_text
+    assert "ExecStart=/home/opc/Sustainacore/.venv/bin/python" in unit_text

--- a/tools/index_engine/pipeline_state.py
+++ b/tools/index_engine/pipeline_state.py
@@ -12,6 +12,7 @@ from db_helper import get_connection
 PIPELINE_STATE_TABLE = "SC_IDX_PIPELINE_STATE"
 DEFAULT_PIPELINE_NAME = "sc_idx_pipeline"
 ORACLE_DETAILS_MAX_CHARS = 3500
+TERMINAL_STAGE_NAMES = {"persist_terminal_status", "release_lock"}
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 DEFAULT_STATE_PATH = REPO_ROOT / "tools" / "audit" / "output" / "pipeline_state_latest.json"
@@ -111,6 +112,13 @@ def _compact_details_for_oracle(details: str | None) -> str | None:
     return text[:ORACLE_DETAILS_MAX_CHARS]
 
 
+def _is_terminal_stage_record(stage_name: str | None, status: str | None) -> bool:
+    return (
+        str(stage_name or "") in TERMINAL_STAGE_NAMES
+        and str(status or "").strip().upper() != "STARTED"
+    )
+
+
 @dataclass
 class StageRecord:
     status: str
@@ -204,31 +212,70 @@ class PipelineStateStore:
     def create_run_id(self) -> str:
         return str(uuid.uuid4())
 
-    def fetch_resume_run_id(self, *, run_date: _dt.date | None = None) -> str | None:
-        run_date = run_date or _utc_today()
-        if self._oracle_ok:
-            sql = (
-                "SELECT run_id "
-                "FROM SC_IDX_PIPELINE_STATE "
-                "WHERE pipeline_name = :pipeline_name "
-                "AND started_at >= TRUNC(SYSTIMESTAMP) "
-                "ORDER BY started_at DESC FETCH FIRST 1 ROWS ONLY"
-            )
-            try:
-                with get_connection() as conn:
-                    cur = conn.cursor()
-                    cur.execute(sql, {"pipeline_name": self.pipeline_name})
-                    row = cur.fetchone()
-                    if row and row[0]:
-                        return str(row[0])
-            except Exception:
-                self._oracle_ok = False
+    def _local_resume_run_id(self, *, run_date: _dt.date) -> str | None:
         payload = self._load_local_state()
         if payload.get("pipeline_name") != self.pipeline_name:
             return None
         if payload.get("run_date") != run_date.isoformat():
             return None
+        for stage_name, entry in (payload.get("stages") or {}).items():
+            if _is_terminal_stage_record(str(stage_name), str((entry or {}).get("status") or "")):
+                return None
         return payload.get("run_id")
+
+    def _oracle_resume_run_id(self) -> str | None:
+        sql = (
+            "SELECT run_id, stage_name, stage_status, started_at "
+            "FROM SC_IDX_PIPELINE_STATE "
+            "WHERE pipeline_name = :pipeline_name "
+            "AND started_at >= TRUNC(SYSTIMESTAMP) "
+            "ORDER BY started_at DESC"
+        )
+        try:
+            with get_connection() as conn:
+                cur = conn.cursor()
+                cur.execute(sql, {"pipeline_name": self.pipeline_name})
+                rows = cur.fetchall() or []
+        except Exception:
+            self._oracle_ok = False
+            return None
+
+        runs: Dict[str, Dict[str, Any]] = {}
+        for run_id, stage_name, stage_status, started_at in rows:
+            if not run_id:
+                continue
+            run_key = str(run_id)
+            info = runs.setdefault(
+                run_key,
+                {
+                    "latest_started_at": started_at,
+                    "has_terminal_stage": False,
+                },
+            )
+            if started_at and (
+                info["latest_started_at"] is None or started_at > info["latest_started_at"]
+            ):
+                info["latest_started_at"] = started_at
+            if _is_terminal_stage_record(str(stage_name), str(stage_status)):
+                info["has_terminal_stage"] = True
+
+        candidates = [
+            (run_id, info["latest_started_at"])
+            for run_id, info in runs.items()
+            if not info["has_terminal_stage"]
+        ]
+        if not candidates:
+            return None
+        candidates.sort(key=lambda item: item[1] or _dt.datetime.min, reverse=True)
+        return candidates[0][0]
+
+    def fetch_resume_run_id(self, *, run_date: _dt.date | None = None) -> str | None:
+        run_date = run_date or _utc_today()
+        if self._oracle_ok:
+            resume_run_id = self._oracle_resume_run_id()
+            if resume_run_id:
+                return resume_run_id
+        return self._local_resume_run_id(run_date=run_date)
 
     def fetch_stage_statuses(self, run_id: str) -> Dict[str, StageRecord]:
         stages: Dict[str, StageRecord] = self._load_local_stage_statuses(run_id)


### PR DESCRIPTION
## Summary
- fix the VM1 scheduler path so `sc-idx-pipeline.service` no longer self-blocks on an outer `flock`
- keep blocked/early-failure reports high-signal by backfilling last-known freshness from Oracle after preflight succeeds
- recover production SC_IDX/TECH100 from `2026-03-27` to `2026-03-30` on the corrected runtime

## Changes
- route the VM1 pipeline service directly to `tools/index_engine/run_pipeline.py` and leave lock ownership to LangGraph's internal `acquire_lock`
- hydrate early blocked/failed/clean-skip reports with a health snapshot so `expected_target_date`, freshness lag, repo identity, and downstream table dates do not collapse to `unknown`
- add regressions for blocked-lock short-circuit freshness reporting and for the systemd unit contract
- update `AGENTS.md`, the LangGraph docs, the VM1 verification guide, and the scheduler/systemd runbooks with the new lock ownership rules

## Testing
- `cd /tmp/sustainacore-scidx-recurring-20260331-clone && /mnt/c/codex/Sustainacore/.venv/bin/python -m pytest -q tests/test_run_pipeline.py`
- `cd /tmp/sustainacore-scidx-recurring-20260331-clone && /mnt/c/codex/Sustainacore/.venv/bin/python -m pytest -q tests/test_pipeline_state.py tests/test_index_engine_daily_telemetry_report.py tests/test_systemd_units.py`
- production VM1 recovery run via `sudo systemctl start sc-idx-pipeline.service` on release `/opt/sustainacore-sc-idx-61986daea595`

## Evidence
- Live production before fix:
  - `sc-idx-pipeline.service` ExecStart used `/usr/bin/flock -n /tmp/sc_idx_pipeline.lock ... run_pipeline.py`
  - repeated terminal rows were `BLOCKED` on `2026-03-29`, `2026-03-30`, and `2026-03-31`
  - Oracle max dates were `SC_IDX_TRADING_DAYS=2026-03-30` while `SC_IDX_PRICES_CANON`, `SC_IDX_LEVELS`, `SC_IDX_STATS_DAILY`, `SC_IDX_PORTFOLIO_ANALYTICS_DAILY`, and `SC_IDX_PORTFOLIO_POSITION_DAILY` were stuck at `2026-03-27`
- Live production after fix:
  - scheduler checkout: `/opt/sustainacore-sc-idx-61986daea595`
  - runtime commit: `61986daea59560ef65601819d75cad841ef5adfd`
  - effective unit ExecStart is now `/home/opc/Sustainacore/.venv/bin/python /home/opc/Sustainacore/tools/index_engine/run_pipeline.py`
  - recovery run `d72f43bf-3d0c-44a1-9d29-e385294c2421` started `2026-03-31T20:41:44Z` and ended `2026-03-31T20:50:14Z` with status `OK`
  - Oracle max dates after recovery:
    - `SC_IDX_PRICES_CANON=2026-03-30`
    - `SC_IDX_LEVELS=2026-03-30`
    - `SC_IDX_STATS_DAILY=2026-03-30`
    - `SC_IDX_PORTFOLIO_ANALYTICS_DAILY=2026-03-30`
    - `SC_IDX_PORTFOLIO_POSITION_DAILY=2026-03-30`
  - latest report/telemetry show `overall_health=Healthy`, `terminal_status=success`, `expected_target_date=2026-03-30`, `latest_complete_date=2026-03-30`, `repo_root=/opt/sustainacore-sc-idx-61986daea595`, `repo_head=61986da`
- CI run links: pending at PR creation; I will update once GitHub finishes scheduling checks for this branch

## Notes / Follow-ups
- Root cause chain:
  - previous fixes corrected lock routing/resume behavior inside LangGraph, but the live systemd service still wrapped `run_pipeline.py` in an outer `flock`
  - the timer path therefore self-contended before LangGraph could run, producing recurring `BLOCKED` incidents while manual direct runs could still succeed
  - early blocked reports were also too low-signal because freshness context was only synthesized after `determine_target_dates`
- The March 31, 2026 recovery run also shows why the incident looked like a hang: one-day backfill uses single-ticker provider calls under the configured throttle, so ingest took about 8 minutes before downstream stages closed. That is slow but bounded and now visible in the stage timings.