### PR TITLE
Fix SC_IDX partial calc completion on rebalance days

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -263,6 +263,15 @@ dmesg -T | egrep -i "oom|out of memory|killed process" | tail -n 60
   - `SC_IDX_STALE_ALLOWED_LAG_DAYS` (default 0) defines tolerated lag before the run/report becomes `Stale`.
   - `SC_IDX_TRADING_DAY_FALLBACK_MAX_GAP` (default 3 weekdays) bounds the synthetic weekday fallback used when trading-day refresh degrades on a provider timeout or 403.
   - A stale verdict is raised when prices advance but levels do not, levels advance but stats do not, levels advance but portfolio tables do not, or the latest complete downstream date lags the expected target date.
+- Calc-stage completeness is defined by the slowest required calc table, not only by `SC_IDX_LEVELS`.
+  - Treat `SC_IDX_LEVELS`, `SC_IDX_CONTRIBUTION_DAILY`, and `SC_IDX_STATS_DAILY` as one completion unit.
+  - If levels advance but contribution/stats do not, the next run must re-enter calc instead of reporting `up_to_date`.
+- Portfolio-stage completeness is defined by the slowest required portfolio table, not only by `SC_IDX_PORTFOLIO_ANALYTICS_DAILY`.
+  - Treat `SC_IDX_PORTFOLIO_ANALYTICS_DAILY`, `SC_IDX_PORTFOLIO_POSITION_DAILY`, and `SC_IDX_PORTFOLIO_OPT_INPUTS` as one completion unit.
+  - If analytics advance but positions/optimizer inputs do not, the next run must re-enter portfolio refresh instead of skipping.
+- Success/clean-skip reports must still show last-known downstream freshness when a stage is skipped.
+  - `stats_max_date` should fall back to the pre-run Oracle max if calc was skipped.
+  - `portfolio_position_max_date` should fall back to the pre-run Oracle max if portfolio refresh was skipped.
 - Oracle retry knobs: `SC_IDX_ORACLE_RETRY_ATTEMPTS` (default 5) and `SC_IDX_ORACLE_RETRY_BASE_SEC` (default 1).
 - Impute guardrails: `SC_IDX_IMPUTE_LOOKBACK_DAYS` (default 30) and `SC_IDX_IMPUTE_TIMEOUT_SEC` (default 300).
 - Imputed replacement guardrails: `SC_IDX_IMPUTED_REPLACEMENT_DAYS` (default 30) and `SC_IDX_IMPUTED_REPLACEMENT_LIMIT` (default 10).

--- a/app/index_engine/db_index_calc.py
+++ b/app/index_engine/db_index_calc.py
@@ -18,6 +18,34 @@ def _disable_parallel_dml(conn) -> None:
         return
 
 
+def _coerce_date(value: object) -> _dt.date | None:
+    if value is None:
+        return None
+    if isinstance(value, _dt.datetime):
+        return value.date()
+    if isinstance(value, _dt.date):
+        return value
+    return None
+
+
+def _fetch_max_trade_date(table_name: str, *, index_code: str | None = None) -> _dt.date | None:
+    sql = f"SELECT MAX(trade_date) FROM {table_name}"
+    binds: dict[str, object] = {}
+    if index_code is not None:
+        sql += " WHERE index_code = :index_code"
+        binds["index_code"] = index_code
+    with get_connection() as conn:
+        cur = conn.cursor()
+        cur.execute(sql, binds)
+        row = cur.fetchone()
+        return _coerce_date(row[0] if row else None)
+
+
+def _completion_floor(*dates: _dt.date | None) -> _dt.date | None:
+    present = [day for day in dates if day is not None]
+    return min(present) if present else None
+
+
 def diagnose_missing_canon_sql(
     start: _dt.date,
     end: _dt.date,
@@ -280,21 +308,23 @@ def fetch_existing_levels(start: _dt.date, end: _dt.date) -> dict[_dt.date, floa
 
 
 def fetch_max_level_date() -> _dt.date | None:
-    sql = (
-        "SELECT MAX(trade_date) "
-        "FROM SC_IDX_LEVELS "
-        "WHERE index_code = :index_code"
+    return _fetch_max_trade_date("SC_IDX_LEVELS", index_code=INDEX_CODE)
+
+
+def fetch_max_contribution_date() -> _dt.date | None:
+    return _fetch_max_trade_date("SC_IDX_CONTRIBUTION_DAILY")
+
+
+def fetch_max_stats_date() -> _dt.date | None:
+    return _fetch_max_trade_date("SC_IDX_STATS_DAILY")
+
+
+def fetch_calc_completion_max_date() -> _dt.date | None:
+    return _completion_floor(
+        fetch_max_level_date(),
+        fetch_max_contribution_date(),
+        fetch_max_stats_date(),
     )
-    with get_connection() as conn:
-        cur = conn.cursor()
-        cur.execute(sql, {"index_code": INDEX_CODE})
-        row = cur.fetchone()
-        value = row[0] if row else None
-        if value is None:
-            return None
-        if isinstance(value, _dt.datetime):
-            return value.date()
-        return value
 
 
 def fetch_constituent_weights(trade_date: _dt.date) -> dict[str, float]:
@@ -706,6 +736,9 @@ __all__ = [
     "fetch_latest_price_before",
     "fetch_existing_levels",
     "fetch_max_level_date",
+    "fetch_max_contribution_date",
+    "fetch_max_stats_date",
+    "fetch_calc_completion_max_date",
     "fetch_constituent_weights",
     "fetch_last_level_before",
     "fetch_divisor_for_date",

--- a/app/index_engine/db_portfolio_analytics.py
+++ b/app/index_engine/db_portfolio_analytics.py
@@ -30,6 +30,11 @@ def _coerce_date(value: object) -> _dt.date | None:
     return None
 
 
+def _completion_floor(*dates: _dt.date | None) -> _dt.date | None:
+    present = [day for day in dates if day is not None]
+    return min(present) if present else None
+
+
 def _is_missing_object_error(exc: Exception) -> bool:
     text = str(exc)
     if "ORA-00942" in text or "ORA-04043" in text:
@@ -223,6 +228,18 @@ def fetch_portfolio_position_max_date() -> _dt.date | None:
     return _fetch_max_trade_date("SC_IDX_PORTFOLIO_POSITION_DAILY")
 
 
+def fetch_portfolio_opt_inputs_max_date() -> _dt.date | None:
+    return _fetch_max_trade_date("SC_IDX_PORTFOLIO_OPT_INPUTS")
+
+
+def fetch_portfolio_completion_max_date() -> _dt.date | None:
+    return _completion_floor(
+        fetch_portfolio_analytics_max_date(),
+        fetch_portfolio_position_max_date(),
+        fetch_portfolio_opt_inputs_max_date(),
+    )
+
+
 def _fetch_max_trade_date(table_name: str) -> _dt.date | None:
     sql = f"SELECT MAX(trade_date) FROM {table_name}"
     with get_connection() as conn:
@@ -335,6 +352,8 @@ __all__ = [
     "fetch_official_position_rows",
     "fetch_portfolio_analytics_max_date",
     "fetch_portfolio_position_max_date",
+    "fetch_portfolio_opt_inputs_max_date",
+    "fetch_portfolio_completion_max_date",
     "fetch_price_rows",
     "fetch_trade_date_bounds",
     "persist_outputs",

--- a/app/index_engine/index_calc_v1.py
+++ b/app/index_engine/index_calc_v1.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 
 import datetime as _dt
 import math
-from typing import Dict, Iterable, List, Sequence
+from typing import Dict, Iterable, List, Mapping, Sequence
 
 
 def build_rebalance_schedule(
@@ -135,14 +135,16 @@ def compute_contributions(
     trading_days: Sequence[_dt.date],
     weights_by_date: Dict[_dt.date, Dict[str, float]],
     prices_by_date: Dict[_dt.date, Dict[str, float]],
+    weights_prev_by_date: Mapping[_dt.date, Mapping[str, float]] | None = None,
 ) -> Dict[_dt.date, Dict[str, float]]:
     """Compute per-ticker contribution based on prev-day weights and returns."""
     contributions: Dict[_dt.date, Dict[str, float]] = {}
     ordered = sorted(trading_days)
+    weights_prev_by_date = weights_prev_by_date or {}
     for idx in range(1, len(ordered)):
         prev_date = ordered[idx - 1]
         trade_date = ordered[idx]
-        weights_prev = weights_by_date.get(prev_date, {})
+        weights_prev = weights_prev_by_date.get(trade_date) or weights_by_date.get(prev_date, {})
         prices_prev = prices_by_date.get(prev_date, {})
         prices_now = prices_by_date.get(trade_date, {})
         daily: Dict[str, float] = {}

--- a/app/index_engine/orchestration.py
+++ b/app/index_engine/orchestration.py
@@ -700,9 +700,16 @@ class SCIdxPipelineRuntime:
 
         max_canon_date = engine_db.fetch_max_canon_trade_date()
         max_level_date = db_index_calc.fetch_max_level_date()
+        max_contribution_date = db_index_calc.fetch_max_contribution_date()
+        max_stats_date = db_index_calc.fetch_max_stats_date()
+        max_calc_complete_date = db_index_calc.fetch_calc_completion_max_date()
         max_portfolio_date = db_portfolio_analytics.fetch_portfolio_analytics_max_date()
+        max_portfolio_position_date = db_portfolio_analytics.fetch_portfolio_position_max_date()
+        max_portfolio_opt_inputs_date = db_portfolio_analytics.fetch_portfolio_opt_inputs_max_date()
+        max_portfolio_complete_date = db_portfolio_analytics.fetch_portfolio_completion_max_date()
         next_missing_canon = run_daily.select_next_missing_trading_day(trading_days, max_canon_trade_date=max_canon_date)
-        next_missing_level = _select_next_missing_trading_day(trading_days, max_level_date)
+        next_missing_calc = _select_next_missing_trading_day(trading_days, max_calc_complete_date)
+        next_missing_portfolio = _select_next_missing_trading_day(trading_days, max_portfolio_complete_date)
         ingest_required = (
             not state.get("skip_ingest")
             and candidate_end is not None
@@ -741,7 +748,7 @@ class SCIdxPipelineRuntime:
                 "remediation": "Wait for the UTC budget window to reset or raise the SC_IDX daily call limit.",
             }
 
-        if candidate_end is None and not ingest_required and next_missing_level is None:
+        if candidate_end is None and not ingest_required and next_missing_calc is None and next_missing_portfolio is None:
             return {
                 "status": "SKIP",
                 "detail": "up_to_date",
@@ -758,7 +765,13 @@ class SCIdxPipelineRuntime:
                     "synthetic_trading_days": [day.isoformat() for day in synthetic_days],
                     "max_canon_before": max_canon_date,
                     "max_level_before": max_level_date,
+                    "max_contribution_before": max_contribution_date,
+                    "max_stats_before": max_stats_date,
+                    "max_calc_complete_before": max_calc_complete_date,
                     "max_portfolio_before": max_portfolio_date,
+                    "max_portfolio_position_before": max_portfolio_position_date,
+                    "max_portfolio_opt_inputs_before": max_portfolio_opt_inputs_date,
+                    "max_portfolio_complete_before": max_portfolio_complete_date,
                 },
             }
 
@@ -766,7 +779,8 @@ class SCIdxPipelineRuntime:
         detail = (
             f"candidate_end={candidate_end.isoformat() if candidate_end else None} "
             f"next_missing_canon={next_missing_canon.isoformat() if next_missing_canon else None} "
-            f"next_missing_level={next_missing_level.isoformat() if next_missing_level else None}"
+            f"next_missing_calc={next_missing_calc.isoformat() if next_missing_calc else None} "
+            f"next_missing_portfolio={next_missing_portfolio.isoformat() if next_missing_portfolio else None}"
         )
         context = {
             "today_utc": today_utc,
@@ -778,7 +792,8 @@ class SCIdxPipelineRuntime:
             "trading_days": trading_days,
             "synthetic_trading_days": [day.isoformat() for day in synthetic_days],
             "next_missing_canon_date": next_missing_canon,
-            "next_missing_level_date": next_missing_level,
+            "next_missing_calc_date": next_missing_calc,
+            "next_missing_portfolio_date": next_missing_portfolio,
             "ingest_start_date": next_missing_canon or candidate_end,
             "ingest_required": ingest_required,
             "max_provider_calls": max_provider_calls,
@@ -792,7 +807,13 @@ class SCIdxPipelineRuntime:
             "provider_usage_remaining": provider_usage_remaining,
             "max_canon_before": max_canon_date,
             "max_level_before": max_level_date,
+            "max_contribution_before": max_contribution_date,
+            "max_stats_before": max_stats_date,
+            "max_calc_complete_before": max_calc_complete_date,
             "max_portfolio_before": max_portfolio_date,
+            "max_portfolio_position_before": max_portfolio_position_date,
+            "max_portfolio_opt_inputs_before": max_portfolio_opt_inputs_date,
+            "max_portfolio_complete_before": max_portfolio_complete_date,
         }
         return {
             "status": status,
@@ -1008,8 +1029,11 @@ class SCIdxPipelineRuntime:
                 "error": "trading_days missing from state",
                 "error_token": "no_trading_days",
             }
-        max_level_date = db_index_calc.fetch_max_level_date()
-        target_day = _select_next_missing_trading_day(trading_days, max_level_date)
+        max_calc_complete_date = (
+            _coerce_date(context.get("max_calc_complete_before"))
+            or db_index_calc.fetch_calc_completion_max_date()
+        )
+        target_day = _select_next_missing_trading_day(trading_days, max_calc_complete_date)
         if target_day is None:
             return {"status": "SKIP", "detail": "no_missing_trading_day"}
 
@@ -1273,6 +1297,7 @@ class SCIdxPipelineRuntime:
             }
 
         max_level_after = db_index_calc.fetch_max_level_date()
+        max_contribution_after = db_index_calc.fetch_max_contribution_date()
         max_stats_after = _fetch_current_max_stats_date()
         if max_level_after is None or max_level_after < end_day:
             return {
@@ -1280,6 +1305,16 @@ class SCIdxPipelineRuntime:
                 "detail": "levels_not_advanced",
                 "error": f"target_day={target_day.isoformat()} end_day={end_day.isoformat()} max_level={max_level_after}",
                 "error_token": "levels_not_advanced",
+            }
+        if max_contribution_after is None or max_contribution_after < end_day:
+            return {
+                "status": "FAILED",
+                "detail": "contributions_not_advanced",
+                "error": (
+                    f"target_day={target_day.isoformat()} end_day={end_day.isoformat()} "
+                    f"max_contribution={max_contribution_after}"
+                ),
+                "error_token": "contributions_not_advanced",
             }
         if max_stats_after is None or max_stats_after < end_day:
             return {
@@ -1298,6 +1333,7 @@ class SCIdxPipelineRuntime:
                 "calc_start_date": target_day,
                 "calc_end_date": end_day,
                 "levels_max_after": max_level_after,
+                "contribution_max_after": max_contribution_after,
                 "stats_max_after": max_stats_after,
             },
         }
@@ -1314,14 +1350,30 @@ class SCIdxPipelineRuntime:
             _coerce_date(context.get("max_portfolio_before"))
             or db_portfolio_analytics.fetch_portfolio_analytics_max_date()
         )
-        if portfolio_max_before is not None and portfolio_max_before >= max_level_date:
+        portfolio_position_before = (
+            _coerce_date(context.get("max_portfolio_position_before"))
+            or db_portfolio_analytics.fetch_portfolio_position_max_date()
+        )
+        portfolio_opt_inputs_before = (
+            _coerce_date(context.get("max_portfolio_opt_inputs_before"))
+            or db_portfolio_analytics.fetch_portfolio_opt_inputs_max_date()
+        )
+        portfolio_complete_before = (
+            _coerce_date(context.get("max_portfolio_complete_before"))
+            or db_portfolio_analytics.fetch_portfolio_completion_max_date()
+        )
+        if portfolio_complete_before is not None and portfolio_complete_before >= max_level_date:
             return {
                 "status": "SKIP",
-                "detail": f"portfolio_up_to_date={portfolio_max_before.isoformat()}",
-                "context": {"portfolio_max_after": portfolio_max_before},
+                "detail": f"portfolio_up_to_date={portfolio_complete_before.isoformat()}",
+                "context": {
+                    "portfolio_max_after": portfolio_max_before,
+                    "portfolio_position_max_after": portfolio_position_before,
+                    "portfolio_opt_inputs_max_after": portfolio_opt_inputs_before,
+                },
             }
 
-        start_day = _select_next_missing_trading_day(trading_days, portfolio_max_before) if trading_days else None
+        start_day = _select_next_missing_trading_day(trading_days, portfolio_complete_before) if trading_days else None
         if start_day is None:
             start_day = max(BASE_DATE, max_level_date)
 
@@ -1357,6 +1409,7 @@ class SCIdxPipelineRuntime:
 
         portfolio_max_after = db_portfolio_analytics.fetch_portfolio_analytics_max_date()
         portfolio_position_max_after = db_portfolio_analytics.fetch_portfolio_position_max_date()
+        portfolio_opt_inputs_max_after = db_portfolio_analytics.fetch_portfolio_opt_inputs_max_date()
         if portfolio_max_after is None or portfolio_max_after < max_level_date:
             return {
                 "status": "FAILED",
@@ -1367,6 +1420,28 @@ class SCIdxPipelineRuntime:
                 ),
                 "error_token": "portfolio_not_advanced",
                 "remediation": "Re-run the portfolio refresh for the missing window and verify the additive tables advanced.",
+            }
+        if portfolio_position_max_after is None or portfolio_position_max_after < max_level_date:
+            return {
+                "status": "FAILED",
+                "detail": "portfolio_positions_not_advanced",
+                "error": (
+                    f"start_day={start_day.isoformat()} max_level={max_level_date.isoformat()} "
+                    f"max_portfolio_positions={portfolio_position_max_after}"
+                ),
+                "error_token": "portfolio_positions_not_advanced",
+                "remediation": "Re-run the portfolio refresh for the missing window and verify the position table advanced.",
+            }
+        if portfolio_opt_inputs_max_after is None or portfolio_opt_inputs_max_after < max_level_date:
+            return {
+                "status": "FAILED",
+                "detail": "portfolio_opt_inputs_not_advanced",
+                "error": (
+                    f"start_day={start_day.isoformat()} max_level={max_level_date.isoformat()} "
+                    f"max_portfolio_opt_inputs={portfolio_opt_inputs_max_after}"
+                ),
+                "error_token": "portfolio_opt_inputs_not_advanced",
+                "remediation": "Re-run the portfolio refresh for the missing window and verify the optimizer inputs advanced.",
             }
 
         counts = _query_portfolio_counts(start_day, max_level_date)
@@ -1379,6 +1454,7 @@ class SCIdxPipelineRuntime:
                 "portfolio_end_date": max_level_date,
                 "portfolio_max_after": portfolio_max_after,
                 "portfolio_position_max_after": portfolio_position_max_after,
+                "portfolio_opt_inputs_max_after": portfolio_opt_inputs_max_after,
             },
         }
 
@@ -1778,7 +1854,9 @@ def _hydrate_report_context_with_health_snapshot(
             "calendar_max_date",
             "max_canon_before",
             "max_level_before",
+            "max_stats_before",
             "max_portfolio_before",
+            "max_portfolio_position_before",
             "portfolio_position_max_after",
         )
     )
@@ -1803,8 +1881,10 @@ def _hydrate_report_context_with_health_snapshot(
     _set_context_default(enriched, "expected_target_source", "calendar_snapshot")
     _set_context_default(enriched, "max_canon_before", health.get("canon_max_date"))
     _set_context_default(enriched, "max_level_before", health.get("levels_max_date"))
+    _set_context_default(enriched, "max_stats_before", health.get("stats_max_date"))
     _set_context_default(enriched, "stats_max_after", health.get("stats_max_date"))
     _set_context_default(enriched, "max_portfolio_before", health.get("portfolio_max_date"))
+    _set_context_default(enriched, "max_portfolio_position_before", health.get("portfolio_position_max_date"))
     _set_context_default(enriched, "portfolio_position_max_after", health.get("portfolio_position_max_date"))
     _set_context_default(enriched, "repo_root", health.get("repo_root"))
     _set_context_default(enriched, "repo_head", health.get("repo_head"))

--- a/app/index_engine/run_report.py
+++ b/app/index_engine/run_report.py
@@ -352,9 +352,10 @@ def build_pipeline_run_summary(
     freshness = {
         "canon_max_date": context.get("max_canon_after_ingest") or context.get("max_canon_before"),
         "levels_max_date": context.get("levels_max_after") or context.get("max_level_before"),
-        "stats_max_date": context.get("stats_max_after"),
+        "stats_max_date": context.get("stats_max_after") or context.get("max_stats_before"),
         "portfolio_analytics_max_date": context.get("portfolio_max_after") or context.get("max_portfolio_before"),
-        "portfolio_position_max_date": context.get("portfolio_position_max_after"),
+        "portfolio_position_max_date": context.get("portfolio_position_max_after")
+        or context.get("max_portfolio_position_before"),
     }
     expected_target_date = (
         context.get("expected_target_date")

--- a/docs/index_engine_langgraph_orchestration.md
+++ b/docs/index_engine_langgraph_orchestration.md
@@ -55,8 +55,13 @@ Important routing behavior:
 - `determine_target_dates` can end the run as `clean_skip` for `up_to_date` or `daily_budget_stop`
 - `readiness_probe` can end the run as `clean_skip` for `provider_not_ready`
 - `completeness_check` can degrade into `imputation_or_replacement` instead of failing immediately
+- calc completeness is keyed off the slowest calc-owned table (`SC_IDX_LEVELS`,
+  `SC_IDX_CONTRIBUTION_DAILY`, `SC_IDX_STATS_DAILY`), not just levels
 - `imputation_or_replacement` rechecks completeness before `calc_index`
 - `portfolio_analytics` refreshes additive TECH100 portfolio tables after index/statistics advance
+- portfolio completeness is keyed off the slowest portfolio-owned table
+  (`SC_IDX_PORTFOLIO_ANALYTICS_DAILY`, `SC_IDX_PORTFOLIO_POSITION_DAILY`,
+  `SC_IDX_PORTFOLIO_OPT_INPUTS`), not just analytics
 - `generate_run_report`, `decide_alerts`, `emit_telemetry`, `persist_terminal_status`, and `release_lock`
   still run after failures so the run concludes cleanly
 
@@ -134,6 +139,8 @@ The report includes:
 - stale signals and freshness lag by key table
 - deployed `repo_root` and `repo_head`
 - best-effort last-known freshness even for early blocked/failure exits after Oracle preflight
+- skipped calc/portfolio stages still carry pre-run stats/position freshness so a partial downstream lag
+  cannot be misreported as `Healthy`
 - root cause token
 - next remediation step
 

--- a/docs/index_engine_verify.md
+++ b/docs/index_engine_verify.md
@@ -122,6 +122,9 @@ Expected signals:
   incomplete runs should resume
 - even an early blocked run should still show last-known `expected_target_date`,
   `latest_complete_date`, and key table max dates when Oracle preflight succeeded
+- a run is not truly fresh until `SC_IDX_LEVELS`, `SC_IDX_STATS_DAILY`,
+  `SC_IDX_PORTFOLIO_ANALYTICS_DAILY`, and `SC_IDX_PORTFOLIO_POSITION_DAILY`
+  all reach the same expected target date
 - `SC_IDX_PORTFOLIO_ANALYTICS_DAILY` and `SC_IDX_PORTFOLIO_POSITION_DAILY` max dates match the latest `SC_IDX_LEVELS` trade date
 
 ### 7. Scheduler checks

--- a/docs/telemetry.md
+++ b/docs/telemetry.md
@@ -190,6 +190,8 @@ Signals include:
 - expected target date and source
 - freshness dates for canon, levels, and stats
 - portfolio analytics freshness and alignment
+- skipped calc/portfolio stages still report the last-known stats and portfolio-position dates so
+  partial downstream lag cannot hide behind a nominal `success`
 - stale signals and latest complete lag
 - deployed `repo_root` and `repo_head`
 - remediation and artifact paths

--- a/tests/test_calc_index_seed.py
+++ b/tests/test_calc_index_seed.py
@@ -36,3 +36,26 @@ def test_seed_prior_state_prefers_constituent_shares(monkeypatch):
     assert holdings_by_reb[prev_trade] == shares_prev
     assert pytest.approx(divisors_by_reb[prev_trade], rel=1e-9) == 250.0 / prev_level
     assert levels[prev_trade] == prev_level
+
+
+def test_prime_rebalance_prev_snapshot_backfills_new_basket_prices():
+    prev_date = dt.date(2026, 3, 31)
+    prices_by_date = {prev_date: {"OLD": 90.0}}
+    prices_quality_by_date = {prev_date: {"OLD": "REAL"}}
+
+    weights = calc_index._prime_rebalance_prev_snapshot(
+        prev_date=prev_date,
+        shares={"AAA": 1.0, "BBB": 1.0},
+        price_map_prev={"AAA": 100.0, "BBB": 200.0},
+        quality_map_prev={"AAA": "REAL", "BBB": "REAL"},
+        prices_by_date=prices_by_date,
+        prices_quality_by_date=prices_quality_by_date,
+    )
+
+    assert prices_by_date[prev_date]["OLD"] == 90.0
+    assert prices_by_date[prev_date]["AAA"] == 100.0
+    assert prices_by_date[prev_date]["BBB"] == 200.0
+    assert prices_quality_by_date[prev_date]["AAA"] == "REAL"
+    assert prices_quality_by_date[prev_date]["BBB"] == "REAL"
+    assert weights["AAA"] == pytest.approx(1.0 / 3.0)
+    assert weights["BBB"] == pytest.approx(2.0 / 3.0)

--- a/tests/test_calc_index_window.py
+++ b/tests/test_calc_index_window.py
@@ -12,13 +12,13 @@ def test_select_calc_window_advances_start_date():
     ]
     start_date = dt.date(2025, 1, 2)
     end_date = dt.date(2026, 1, 7)
-    max_level_date = dt.date(2026, 1, 2)
+    max_complete_date = dt.date(2026, 1, 2)
 
     new_start, filtered, status = calc_index._select_calc_window(
         trading_days=trading_days,
         start_date=start_date,
         end_date=end_date,
-        max_level_date=max_level_date,
+        max_complete_date=max_complete_date,
         rebuild=False,
     )
 
@@ -31,16 +31,38 @@ def test_select_calc_window_noop_when_up_to_date():
     trading_days = [dt.date(2026, 1, 2)]
     start_date = dt.date(2025, 1, 2)
     end_date = dt.date(2026, 1, 2)
-    max_level_date = dt.date(2026, 1, 2)
+    max_complete_date = dt.date(2026, 1, 2)
 
     new_start, filtered, status = calc_index._select_calc_window(
         trading_days=trading_days,
         start_date=start_date,
         end_date=end_date,
-        max_level_date=max_level_date,
+        max_complete_date=max_complete_date,
         rebuild=False,
     )
 
     assert status == "up_to_date"
     assert filtered == []
     assert new_start == start_date
+
+
+def test_select_calc_window_reprocesses_when_stats_lag_levels():
+    trading_days = [
+        dt.date(2026, 3, 31),
+        dt.date(2026, 4, 1),
+    ]
+    start_date = dt.date(2026, 4, 1)
+    end_date = dt.date(2026, 4, 1)
+    max_complete_date = dt.date(2026, 3, 31)
+
+    new_start, filtered, status = calc_index._select_calc_window(
+        trading_days=trading_days,
+        start_date=start_date,
+        end_date=end_date,
+        max_complete_date=max_complete_date,
+        rebuild=False,
+    )
+
+    assert status is None
+    assert new_start == dt.date(2026, 4, 1)
+    assert filtered == [dt.date(2026, 4, 1)]

--- a/tests/test_index_calc_v1.py
+++ b/tests/test_index_calc_v1.py
@@ -2,6 +2,8 @@ import datetime as dt
 import sys
 from pathlib import Path
 
+import pytest
+
 REPO_ROOT = Path(__file__).resolve().parents[1]
 APP_ROOT = REPO_ROOT / "app"
 if str(APP_ROOT) not in sys.path:
@@ -87,3 +89,30 @@ def test_stats_top5_and_herfindahl() -> None:
     day2 = stats[trading_days[1]]
     assert round(day2["top5_weight"], 6) == 1.0
     assert round(day2["herfindahl"], 6) == round(0.5365853659**2 + 0.4634146341**2, 6)
+
+
+def test_rebalance_day_contributions_can_use_rebalance_weights() -> None:
+    trading_days = [dt.date(2026, 3, 31), dt.date(2026, 4, 1)]
+    prices_by_date = {
+        trading_days[0]: {"AAA": 100.0, "BBB": 100.0},
+        trading_days[1]: {"AAA": 100.0, "BBB": 200.0},
+    }
+    weights_by_date = {
+        trading_days[0]: {"AAA": 0.9, "BBB": 0.1},
+        trading_days[1]: {"AAA": 0.5, "BBB": 0.5},
+    }
+
+    default_contrib = compute_contributions(
+        trading_days=trading_days,
+        weights_by_date=weights_by_date,
+        prices_by_date=prices_by_date,
+    )
+    rebalance_contrib = compute_contributions(
+        trading_days=trading_days,
+        weights_by_date=weights_by_date,
+        prices_by_date=prices_by_date,
+        weights_prev_by_date={trading_days[1]: {"AAA": 0.5, "BBB": 0.5}},
+    )
+
+    assert sum(default_contrib[trading_days[1]].values()) == pytest.approx(0.1)
+    assert sum(rebalance_contrib[trading_days[1]].values()) == pytest.approx(0.5)

--- a/tests/test_run_pipeline.py
+++ b/tests/test_run_pipeline.py
@@ -361,8 +361,23 @@ def test_determine_target_dates_uses_defaults_for_blank_budget_env(monkeypatch, 
     monkeypatch.setattr("index_engine.orchestration.fetch_calls_used_today", lambda *_args, **_kwargs: 0)
     monkeypatch.setattr("index_engine.orchestration.engine_db.fetch_max_canon_trade_date", lambda: dt.date(2026, 3, 25))
     monkeypatch.setattr("index_engine.orchestration.db_index_calc.fetch_max_level_date", lambda: dt.date(2026, 3, 25))
+    monkeypatch.setattr("index_engine.orchestration.db_index_calc.fetch_max_contribution_date", lambda: dt.date(2026, 3, 25))
+    monkeypatch.setattr("index_engine.orchestration.db_index_calc.fetch_max_stats_date", lambda: dt.date(2026, 3, 25))
+    monkeypatch.setattr("index_engine.orchestration.db_index_calc.fetch_calc_completion_max_date", lambda: dt.date(2026, 3, 25))
     monkeypatch.setattr(
         "index_engine.orchestration.db_portfolio_analytics.fetch_portfolio_analytics_max_date",
+        lambda: dt.date(2026, 3, 25),
+    )
+    monkeypatch.setattr(
+        "index_engine.orchestration.db_portfolio_analytics.fetch_portfolio_position_max_date",
+        lambda: dt.date(2026, 3, 25),
+    )
+    monkeypatch.setattr(
+        "index_engine.orchestration.db_portfolio_analytics.fetch_portfolio_opt_inputs_max_date",
+        lambda: dt.date(2026, 3, 25),
+    )
+    monkeypatch.setattr(
+        "index_engine.orchestration.db_portfolio_analytics.fetch_portfolio_completion_max_date",
         lambda: dt.date(2026, 3, 25),
     )
     monkeypatch.setenv("SC_IDX_MARKET_DATA_DAILY_LIMIT", "")
@@ -377,6 +392,124 @@ def test_determine_target_dates_uses_defaults_for_blank_budget_env(monkeypatch, 
     assert result["context"]["daily_limit"] == 800
     assert result["context"]["daily_buffer"] == 25
     assert result["context"]["max_provider_calls"] == 775
+
+
+def test_determine_target_dates_keeps_calc_and_portfolio_work_when_downstream_tables_lag(monkeypatch, tmp_path):
+    trading_days = [dt.date(2026, 3, 31), dt.date(2026, 4, 1)]
+    provider = SimpleNamespace(fetch_api_usage=lambda: {"current_usage": 1, "plan_limit": 8})
+    trading_days_module = SimpleNamespace(update_trading_days_with_retry=lambda **kwargs: (True, None))
+    fake_run_daily = SimpleNamespace(
+        PROBE_SYMBOL_ENV="SC_IDX_PROBE_SYMBOL",
+        DAILY_LIMIT_ENV="SC_IDX_MARKET_DATA_DAILY_LIMIT",
+        DAILY_BUFFER_ENV="SC_IDX_MARKET_DATA_DAILY_BUFFER",
+        BUFFER_ENV="SC_IDX_MARKET_DATA_CREDIT_BUFFER",
+        DEFAULT_DAILY_LIMIT=800,
+        DEFAULT_BUFFER=25,
+        TRADING_DAYS_RETRY_ENV="SC_IDX_TRADING_DAYS_RETRY_ATTEMPTS",
+        TRADING_DAYS_RETRY_BASE_ENV="SC_IDX_TRADING_DAYS_RETRY_BASE_SEC",
+        _load_provider_module=lambda: provider,
+        _load_trading_days_module=lambda: trading_days_module,
+        _compute_daily_budget=lambda daily_limit, daily_buffer, calls_used_today: (
+            daily_limit - calls_used_today,
+            max(0, daily_limit - calls_used_today - daily_buffer),
+        ),
+        _resolve_end_date=lambda provider, probe_symbol, today_utc: (
+            dt.date(2026, 4, 1),
+            trading_days,
+            dt.date(2026, 4, 1),
+        ),
+        derive_expected_target_date=lambda provider_latest, today_utc, trading_days, allow_weekday_fallback: (
+            dt.date(2026, 4, 1),
+            "calendar",
+            trading_days,
+            [],
+        ),
+        select_next_missing_trading_day=lambda trading_days, max_canon_trade_date=None: None,
+        compute_eligible_end_date=lambda provider_latest, today_utc, trading_days: dt.date(2026, 4, 1),
+    )
+    runtime = SCIdxPipelineRuntime(
+        report_dir=tmp_path,
+        telemetry_dir=tmp_path / "telemetry",
+        state_store=_FakeStore(),
+    )
+
+    monkeypatch.setattr(runtime, "_load_run_daily_module", lambda: fake_run_daily)
+    monkeypatch.setattr("index_engine.orchestration.fetch_calls_used_today", lambda *_args, **_kwargs: 0)
+    monkeypatch.setattr("index_engine.orchestration.engine_db.fetch_max_canon_trade_date", lambda: dt.date(2026, 4, 1))
+    monkeypatch.setattr("index_engine.orchestration.db_index_calc.fetch_max_level_date", lambda: dt.date(2026, 4, 1))
+    monkeypatch.setattr("index_engine.orchestration.db_index_calc.fetch_max_contribution_date", lambda: dt.date(2026, 4, 1))
+    monkeypatch.setattr("index_engine.orchestration.db_index_calc.fetch_max_stats_date", lambda: dt.date(2026, 3, 31))
+    monkeypatch.setattr("index_engine.orchestration.db_index_calc.fetch_calc_completion_max_date", lambda: dt.date(2026, 3, 31))
+    monkeypatch.setattr(
+        "index_engine.orchestration.db_portfolio_analytics.fetch_portfolio_analytics_max_date",
+        lambda: dt.date(2026, 4, 1),
+    )
+    monkeypatch.setattr(
+        "index_engine.orchestration.db_portfolio_analytics.fetch_portfolio_position_max_date",
+        lambda: dt.date(2026, 3, 31),
+    )
+    monkeypatch.setattr(
+        "index_engine.orchestration.db_portfolio_analytics.fetch_portfolio_opt_inputs_max_date",
+        lambda: dt.date(2026, 4, 1),
+    )
+    monkeypatch.setattr(
+        "index_engine.orchestration.db_portfolio_analytics.fetch_portfolio_completion_max_date",
+        lambda: dt.date(2026, 3, 31),
+    )
+
+    result = runtime.determine_target_dates(_state(smoke=False))
+
+    assert result["status"] == "OK"
+    assert result["context"]["next_missing_calc_date"] == dt.date(2026, 4, 1)
+    assert result["context"]["next_missing_portfolio_date"] == dt.date(2026, 4, 1)
+    assert result["context"]["max_stats_before"] == dt.date(2026, 3, 31)
+    assert result["context"]["max_portfolio_position_before"] == dt.date(2026, 3, 31)
+
+
+def test_portfolio_analytics_reruns_when_positions_lag(monkeypatch, tmp_path):
+    captured = {}
+    runtime = SCIdxPipelineRuntime(
+        report_dir=tmp_path,
+        telemetry_dir=tmp_path / "telemetry",
+        state_store=_FakeStore(),
+    )
+
+    def _fake_main(argv):
+        captured["argv"] = argv
+        return 0
+
+    monkeypatch.setattr(runtime, "_load_portfolio_analytics_module", lambda: SimpleNamespace(main=_fake_main))
+    monkeypatch.setattr("index_engine.orchestration.db_portfolio_analytics.fetch_portfolio_analytics_max_date", lambda: dt.date(2026, 4, 1))
+    monkeypatch.setattr(
+        "index_engine.orchestration.db_portfolio_analytics.fetch_portfolio_position_max_date",
+        lambda: dt.date(2026, 4, 1),
+    )
+    monkeypatch.setattr(
+        "index_engine.orchestration.db_portfolio_analytics.fetch_portfolio_opt_inputs_max_date",
+        lambda: dt.date(2026, 4, 1),
+    )
+    monkeypatch.setattr(
+        "index_engine.orchestration._query_portfolio_counts",
+        lambda start_date, end_date: {"portfolio_analytics_rows": 6, "portfolio_position_rows": 18},
+    )
+
+    state = _state(
+        smoke=False,
+        context={
+            "trading_days": ["2026-03-31", "2026-04-01"],
+            "levels_max_after": dt.date(2026, 4, 1),
+            "max_portfolio_before": dt.date(2026, 4, 1),
+            "max_portfolio_position_before": dt.date(2026, 3, 31),
+            "max_portfolio_opt_inputs_before": dt.date(2026, 4, 1),
+            "max_portfolio_complete_before": dt.date(2026, 3, 31),
+        },
+    )
+
+    result = runtime.portfolio_analytics(state)
+
+    assert result["status"] == "OK"
+    assert captured["argv"][captured["argv"].index("--start") + 1] == "2026-04-01"
+    assert result["context"]["portfolio_position_max_after"] == dt.date(2026, 4, 1)
 
 
 def test_calc_index_main_accepts_optional_argv():

--- a/tests/test_run_report.py
+++ b/tests/test_run_report.py
@@ -1,0 +1,44 @@
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+APP_ROOT = REPO_ROOT / "app"
+for path in (REPO_ROOT, APP_ROOT):
+    if str(path) not in sys.path:
+        sys.path.insert(0, str(path))
+
+from index_engine.run_report import build_pipeline_run_summary
+
+
+def test_build_pipeline_run_summary_marks_success_stale_when_stats_before_lag():
+    summary = build_pipeline_run_summary(
+        run_id="run-stale",
+        terminal_status="success",
+        started_at="2026-04-02T05:30:24+00:00",
+        stage_results={
+            "determine_target_dates": {"status": "OK", "counts": {}, "attempts": 1},
+            "calc_index": {"status": "SKIP", "counts": {}, "attempts": 1},
+            "portfolio_analytics": {"status": "SKIP", "counts": {}, "attempts": 1},
+        },
+        context={
+            "ended_at": "2026-04-02T05:30:29+00:00",
+            "expected_target_date": "2026-04-01",
+            "expected_target_source": "calendar",
+            "max_canon_before": "2026-04-01",
+            "max_level_before": "2026-04-01",
+            "max_stats_before": "2026-03-31",
+            "max_portfolio_before": "2026-04-01",
+            "max_portfolio_position_before": "2026-04-01",
+            "repo_root": "/repo",
+            "repo_head": "abc1234",
+        },
+        warnings=[],
+        status_reason=None,
+        root_cause=None,
+        remediation=None,
+    )
+
+    assert summary["overall_health"] == "Stale"
+    assert summary["freshness"]["stats_max_date"] == "2026-03-31"
+    assert summary["freshness"]["health"]["verdict"] == "stale"
+    assert "stats_behind_levels" in summary["freshness"]["health"]["stale_signals"]

--- a/tools/index_engine/calc_index.py
+++ b/tools/index_engine/calc_index.py
@@ -161,6 +161,25 @@ def _collect_missing(
     return missing
 
 
+def _weights_from_shares_and_prices(
+    *,
+    shares: Dict[str, float],
+    prices: Dict[str, float],
+) -> Dict[str, float]:
+    market_values = {
+        ticker: shares[ticker] * prices[ticker]
+        for ticker in shares
+        if ticker in prices and prices[ticker] > 0
+    }
+    total_market_value = sum(market_values.values())
+    if total_market_value <= 0:
+        return {}
+    return {
+        ticker: market_value / total_market_value
+        for ticker, market_value in market_values.items()
+    }
+
+
 def _attempt_missing_backfill(
     *,
     trade_date: _dt.date,
@@ -505,6 +524,7 @@ def main(argv: list[str] | None = None) -> int:
     prices_by_date: Dict[_dt.date, Dict[str, float]] = {}
     prices_quality_by_date: Dict[_dt.date, Dict[str, str]] = {}
     weights_by_date: Dict[_dt.date, Dict[str, float]] = {}
+    contrib_weights_prev_by_trade: Dict[_dt.date, Dict[str, float]] = {}
     levels: Dict[_dt.date, float] = {}
     returns_1d: Dict[_dt.date, float] = {}
     missing_by_date: Dict[_dt.date, list[str]] = {}
@@ -614,6 +634,12 @@ def main(argv: list[str] | None = None) -> int:
                 level_prev=prev_level,
                 divisor_prev=prev_divisor,
             )
+            rebalance_weights_prev = _weights_from_shares_and_prices(
+                shares=shares,
+                prices=price_map_prev,
+            )
+            if rebalance_weights_prev:
+                contrib_weights_prev_by_trade[trade_date] = rebalance_weights_prev
             current_reb = trade_date
             prev_port_date = port_date
             holdings_by_reb[trade_date] = shares
@@ -753,12 +779,14 @@ def main(argv: list[str] | None = None) -> int:
         trading_days=ordered_levels,
         weights_by_date=weights_by_date,
         prices_by_date=prices_by_date,
+        weights_prev_by_date=contrib_weights_prev_by_trade,
     )
     contrib_rows = []
     for trade_date, rows in contributions.items():
         prev_date = _prev_trading_day(ordered_levels, trade_date)
+        weight_prev_map = contrib_weights_prev_by_trade.get(trade_date) or weights_by_date.get(prev_date, {})
         for ticker, contribution in rows.items():
-            weight_prev = weights_by_date.get(prev_date, {}).get(ticker)
+            weight_prev = weight_prev_map.get(ticker)
             ret_1d = None
             if prev_date and ticker in prices_by_date.get(prev_date, {}) and ticker in prices_by_date.get(trade_date, {}):
                 p0 = prices_by_date[prev_date][ticker]

--- a/tools/index_engine/calc_index.py
+++ b/tools/index_engine/calc_index.py
@@ -68,16 +68,16 @@ def _select_calc_window(
     trading_days: List[_dt.date],
     start_date: _dt.date,
     end_date: _dt.date,
-    max_level_date: _dt.date | None,
+    max_complete_date: _dt.date | None,
     rebuild: bool,
 ) -> tuple[_dt.date, List[_dt.date], str | None]:
     if not trading_days:
         return start_date, trading_days, "no_trading_days"
-    if rebuild or max_level_date is None:
+    if rebuild or max_complete_date is None:
         return start_date, trading_days, None
-    if end_date <= max_level_date:
+    if end_date <= max_complete_date:
         return start_date, [], "up_to_date"
-    next_day = _next_trading_day(trading_days, max_level_date)
+    next_day = _next_trading_day(trading_days, max_complete_date)
     if next_day is None:
         return start_date, [], "missing_next_trading_day"
     if next_day > start_date:
@@ -394,12 +394,12 @@ def main(argv: list[str] | None = None) -> int:
         return 0
 
     trading_days = db.fetch_trading_days(start_date, end_date)
-    max_level_date = db.fetch_max_level_date()
+    max_complete_date = db.fetch_calc_completion_max_date()
     start_date, trading_days, window_status = _select_calc_window(
         trading_days=trading_days,
         start_date=start_date,
         end_date=end_date,
-        max_level_date=max_level_date,
+        max_complete_date=max_complete_date,
         rebuild=args.rebuild,
     )
     if window_status == "up_to_date":

--- a/tools/index_engine/calc_index.py
+++ b/tools/index_engine/calc_index.py
@@ -180,6 +180,23 @@ def _weights_from_shares_and_prices(
     }
 
 
+def _prime_rebalance_prev_snapshot(
+    *,
+    prev_date: _dt.date,
+    shares: Dict[str, float],
+    price_map_prev: Dict[str, float],
+    quality_map_prev: Dict[str, str],
+    prices_by_date: Dict[_dt.date, Dict[str, float]],
+    prices_quality_by_date: Dict[_dt.date, Dict[str, str]],
+) -> Dict[str, float]:
+    prices_by_date.setdefault(prev_date, {}).update(price_map_prev)
+    prices_quality_by_date.setdefault(prev_date, {}).update(quality_map_prev)
+    return _weights_from_shares_and_prices(
+        shares=shares,
+        prices=price_map_prev,
+    )
+
+
 def _attempt_missing_backfill(
     *,
     trade_date: _dt.date,
@@ -634,9 +651,17 @@ def main(argv: list[str] | None = None) -> int:
                 level_prev=prev_level,
                 divisor_prev=prev_divisor,
             )
-            rebalance_weights_prev = _weights_from_shares_and_prices(
+            rebalance_weights_prev = _prime_rebalance_prev_snapshot(
+                prev_date=prev_date,
                 shares=shares,
-                prices=price_map_prev,
+                price_map_prev=price_map_prev,
+                quality_map_prev={
+                    ticker: str(info.get("quality") or "").upper()
+                    for ticker, info in prices_prev.items()
+                    if info.get("price") is not None
+                },
+                prices_by_date=prices_by_date,
+                prices_quality_by_date=prices_quality_by_date,
             )
             if rebalance_weights_prev:
                 contrib_weights_prev_by_trade[trade_date] = rebalance_weights_prev


### PR DESCRIPTION
## Summary
- fix the recurring SC_IDX stall where benchmark levels advanced but stats stayed one day behind
- harden the calc path for rebalance days so contribution validation uses the effective rebalance basket
- keep production evidence in the PR for the 2026-04-02 recovery to `2026-04-01`

## Changes
- track calc completion from the full calc-owned floor instead of levels alone so partial calc runs cannot be misclassified as fresh
- on rebalance days, compute contribution checks from rebalance-effective prior-close weights instead of stale pre-rebalance weights
- prime prior-close prices for the new rebalance basket before contribution validation so new entrants are not silently dropped from the return sum
- add regression coverage for rebalance contribution weights and rebalance-price priming

## Testing
- `.venv/bin/python -m py_compile app/index_engine/index_calc_v1.py tools/index_engine/calc_index.py app/index_engine/orchestration.py app/index_engine/run_report.py`
- `.venv/bin/python -m pytest -q tests/test_index_calc_v1.py tests/test_calc_index_seed.py tests/test_calc_index_window.py tests/test_run_pipeline.py tests/test_run_pipeline_helpers.py tests/test_run_report.py tests/test_index_engine_daily_telemetry_report.py`
  - result: `36 passed`

## Evidence
- Runtime identity after deploy:
  - `repo_root=/opt/sustainacore-sc-idx-2f38ef364c89`
  - `repo_head=2f38ef3`
- Failed recovery before the final patch:
  - pipeline run `0387ebf2-762f-4032-a341-e401cab3c174`
  - calc runs `bcca0002-c2ed-41fc-8cf5-b80d09535aa9` and `03992291-8986-4be2-98d4-0aafaeb64c50`
  - error: `contrib_mismatch:date=2026-04-01 index_ret=0.03937098 contrib_sum=0.00526122`
- Successful recovery after the final patch:
  - pipeline run `357ae359-eccb-4421-ac5a-b3eedbc07478` `OK`
  - calc run `88378947-3dd8-4cef-8aac-7edc83650968` `OK`
- Oracle freshness after recovery:
  - `SC_IDX_TRADING_DAYS=2026-04-01`
  - `SC_IDX_PRICES_CANON=2026-04-01`
  - `SC_IDX_LEVELS=2026-04-01`
  - `SC_IDX_STATS_DAILY=2026-04-01`
  - `SC_IDX_PORTFOLIO_ANALYTICS_DAILY=2026-04-01`
  - `SC_IDX_PORTFOLIO_POSITION_DAILY=2026-04-01`
- Latest stage state for `357ae359-eccb-4421-ac5a-b3eedbc07478`:
  - `determine_target_dates=OK`
  - `completeness_check=OK`
  - `calc_index=OK`
  - `portfolio_analytics=SKIP` with `portfolio_up_to_date=2026-04-01`
  - `release_lock=OK`
- Portfolio downstream sanity after calc repair:
  - `SC_IDX_PORTFOLIO_POSITION_DAILY` on `2026-04-01` has `sc_idx_null_contrib=0` and `sc_idx_null_ret=0`

## Notes / Follow-ups
- Prior fixes removed deploy drift and scheduler self-locking, but they still allowed a partial calc completion state when a rebalance-day contribution check failed after levels were already written.
- This patch closes that remaining gap by making calc completion and rebalance-day contribution validation mathematically consistent with the rebalance mechanics.
- I did not change workflows or unrelated VM2/UI code.