### PR TITLE
Fix portfolio optimizer input freshness

### DIFF
--- a/app/index_engine/db_portfolio_analytics.py
+++ b/app/index_engine/db_portfolio_analytics.py
@@ -232,12 +232,45 @@ def fetch_portfolio_opt_inputs_max_date() -> _dt.date | None:
     return _fetch_max_trade_date("SC_IDX_PORTFOLIO_OPT_INPUTS")
 
 
-def fetch_portfolio_completion_max_date() -> _dt.date | None:
-    return _completion_floor(
-        fetch_portfolio_analytics_max_date(),
-        fetch_portfolio_position_max_date(),
-        fetch_portfolio_opt_inputs_max_date(),
+def fetch_latest_required_portfolio_opt_inputs_date(
+    end_date: _dt.date | None = None,
+) -> _dt.date | None:
+    sql = (
+        "SELECT MAX(rebalance_date) "
+        "FROM SC_IDX_CONSTITUENT_DAILY "
+        "WHERE rebalance_date IS NOT NULL "
     )
+    params: dict[str, object] = {}
+    if end_date is not None:
+        sql += "AND trade_date <= :end_date"
+        params["end_date"] = end_date
+    with get_connection() as conn:
+        cur = conn.cursor()
+        try:
+            cur.execute(sql, params)
+        except Exception as exc:
+            if _is_missing_object_error(exc):
+                return None
+            raise
+        row = cur.fetchone()
+        return _coerce_date(row[0]) if row else None
+
+
+def fetch_portfolio_completion_max_date() -> _dt.date | None:
+    analytics_max = fetch_portfolio_analytics_max_date()
+    position_max = fetch_portfolio_position_max_date()
+    daily_floor = _completion_floor(analytics_max, position_max)
+    if daily_floor is None:
+        return None
+
+    required_opt_inputs_date = fetch_latest_required_portfolio_opt_inputs_date(daily_floor)
+    if required_opt_inputs_date is None:
+        return daily_floor
+
+    opt_inputs_max = fetch_portfolio_opt_inputs_max_date()
+    if opt_inputs_max is not None and opt_inputs_max >= required_opt_inputs_date:
+        return daily_floor
+    return opt_inputs_max
 
 
 def _fetch_max_trade_date(table_name: str) -> _dt.date | None:
@@ -353,6 +386,7 @@ __all__ = [
     "fetch_portfolio_analytics_max_date",
     "fetch_portfolio_position_max_date",
     "fetch_portfolio_opt_inputs_max_date",
+    "fetch_latest_required_portfolio_opt_inputs_date",
     "fetch_portfolio_completion_max_date",
     "fetch_price_rows",
     "fetch_trade_date_bounds",

--- a/app/index_engine/orchestration.py
+++ b/app/index_engine/orchestration.py
@@ -1410,6 +1410,9 @@ class SCIdxPipelineRuntime:
         portfolio_max_after = db_portfolio_analytics.fetch_portfolio_analytics_max_date()
         portfolio_position_max_after = db_portfolio_analytics.fetch_portfolio_position_max_date()
         portfolio_opt_inputs_max_after = db_portfolio_analytics.fetch_portfolio_opt_inputs_max_date()
+        portfolio_opt_inputs_required_date = db_portfolio_analytics.fetch_latest_required_portfolio_opt_inputs_date(
+            max_level_date
+        )
         if portfolio_max_after is None or portfolio_max_after < max_level_date:
             return {
                 "status": "FAILED",
@@ -1432,16 +1435,23 @@ class SCIdxPipelineRuntime:
                 "error_token": "portfolio_positions_not_advanced",
                 "remediation": "Re-run the portfolio refresh for the missing window and verify the position table advanced.",
             }
-        if portfolio_opt_inputs_max_after is None or portfolio_opt_inputs_max_after < max_level_date:
+        if portfolio_opt_inputs_required_date is not None and (
+            portfolio_opt_inputs_max_after is None
+            or portfolio_opt_inputs_max_after < portfolio_opt_inputs_required_date
+        ):
             return {
                 "status": "FAILED",
                 "detail": "portfolio_opt_inputs_not_advanced",
                 "error": (
                     f"start_day={start_day.isoformat()} max_level={max_level_date.isoformat()} "
+                    f"required_opt_inputs_date={portfolio_opt_inputs_required_date.isoformat()} "
                     f"max_portfolio_opt_inputs={portfolio_opt_inputs_max_after}"
                 ),
                 "error_token": "portfolio_opt_inputs_not_advanced",
-                "remediation": "Re-run the portfolio refresh for the missing window and verify the optimizer inputs advanced.",
+                "remediation": (
+                    "Re-run the portfolio refresh for the missing rebalance window and verify the optimizer inputs "
+                    "advanced through the latest required rebalance date."
+                ),
             }
 
         counts = _query_portfolio_counts(start_day, max_level_date)
@@ -1455,6 +1465,7 @@ class SCIdxPipelineRuntime:
                 "portfolio_max_after": portfolio_max_after,
                 "portfolio_position_max_after": portfolio_position_max_after,
                 "portfolio_opt_inputs_max_after": portfolio_opt_inputs_max_after,
+                "portfolio_opt_inputs_required_date": portfolio_opt_inputs_required_date,
             },
         }
 

--- a/tests/test_db_portfolio_analytics.py
+++ b/tests/test_db_portfolio_analytics.py
@@ -1,4 +1,5 @@
 import sys
+import datetime as dt
 from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[1]
@@ -35,3 +36,53 @@ def test_fetch_portfolio_analytics_max_date_returns_none_when_table_missing(monk
     )
     assert db_portfolio_analytics.fetch_portfolio_analytics_max_date() is None
     assert db_portfolio_analytics.fetch_portfolio_position_max_date() is None
+
+
+def test_fetch_portfolio_completion_max_date_uses_daily_floor_when_opt_inputs_cover_latest_rebalance(monkeypatch):
+    monkeypatch.setattr(
+        db_portfolio_analytics,
+        "fetch_portfolio_analytics_max_date",
+        lambda: dt.date(2026, 4, 2),
+    )
+    monkeypatch.setattr(
+        db_portfolio_analytics,
+        "fetch_portfolio_position_max_date",
+        lambda: dt.date(2026, 4, 2),
+    )
+    monkeypatch.setattr(
+        db_portfolio_analytics,
+        "fetch_portfolio_opt_inputs_max_date",
+        lambda: dt.date(2026, 4, 1),
+    )
+    monkeypatch.setattr(
+        db_portfolio_analytics,
+        "fetch_latest_required_portfolio_opt_inputs_date",
+        lambda end_date: dt.date(2026, 4, 1),
+    )
+
+    assert db_portfolio_analytics.fetch_portfolio_completion_max_date() == dt.date(2026, 4, 2)
+
+
+def test_fetch_portfolio_completion_max_date_stays_back_when_latest_rebalance_inputs_missing(monkeypatch):
+    monkeypatch.setattr(
+        db_portfolio_analytics,
+        "fetch_portfolio_analytics_max_date",
+        lambda: dt.date(2026, 4, 2),
+    )
+    monkeypatch.setattr(
+        db_portfolio_analytics,
+        "fetch_portfolio_position_max_date",
+        lambda: dt.date(2026, 4, 2),
+    )
+    monkeypatch.setattr(
+        db_portfolio_analytics,
+        "fetch_portfolio_opt_inputs_max_date",
+        lambda: dt.date(2026, 4, 1),
+    )
+    monkeypatch.setattr(
+        db_portfolio_analytics,
+        "fetch_latest_required_portfolio_opt_inputs_date",
+        lambda end_date: dt.date(2026, 4, 2),
+    )
+
+    assert db_portfolio_analytics.fetch_portfolio_completion_max_date() == dt.date(2026, 4, 1)

--- a/tests/test_run_pipeline.py
+++ b/tests/test_run_pipeline.py
@@ -489,6 +489,10 @@ def test_portfolio_analytics_reruns_when_positions_lag(monkeypatch, tmp_path):
         lambda: dt.date(2026, 4, 1),
     )
     monkeypatch.setattr(
+        "index_engine.orchestration.db_portfolio_analytics.fetch_latest_required_portfolio_opt_inputs_date",
+        lambda end_date: dt.date(2026, 4, 1),
+    )
+    monkeypatch.setattr(
         "index_engine.orchestration._query_portfolio_counts",
         lambda start_date, end_date: {"portfolio_analytics_rows": 6, "portfolio_position_rows": 18},
     )
@@ -510,6 +514,104 @@ def test_portfolio_analytics_reruns_when_positions_lag(monkeypatch, tmp_path):
     assert result["status"] == "OK"
     assert captured["argv"][captured["argv"].index("--start") + 1] == "2026-04-01"
     assert result["context"]["portfolio_position_max_after"] == dt.date(2026, 4, 1)
+
+
+def test_portfolio_analytics_accepts_rebalance_scoped_optimizer_inputs(monkeypatch, tmp_path):
+    captured = {}
+    runtime = SCIdxPipelineRuntime(
+        report_dir=tmp_path,
+        telemetry_dir=tmp_path / "telemetry",
+        state_store=_FakeStore(),
+    )
+
+    def _fake_main(argv):
+        captured["argv"] = argv
+        return 0
+
+    monkeypatch.setattr(runtime, "_load_portfolio_analytics_module", lambda: SimpleNamespace(main=_fake_main))
+    monkeypatch.setattr(
+        "index_engine.orchestration.db_portfolio_analytics.fetch_portfolio_analytics_max_date",
+        lambda: dt.date(2026, 4, 2),
+    )
+    monkeypatch.setattr(
+        "index_engine.orchestration.db_portfolio_analytics.fetch_portfolio_position_max_date",
+        lambda: dt.date(2026, 4, 2),
+    )
+    monkeypatch.setattr(
+        "index_engine.orchestration.db_portfolio_analytics.fetch_portfolio_opt_inputs_max_date",
+        lambda: dt.date(2026, 4, 1),
+    )
+    monkeypatch.setattr(
+        "index_engine.orchestration.db_portfolio_analytics.fetch_latest_required_portfolio_opt_inputs_date",
+        lambda end_date: dt.date(2026, 4, 1),
+    )
+    monkeypatch.setattr(
+        "index_engine.orchestration._query_portfolio_counts",
+        lambda start_date, end_date: {"portfolio_analytics_rows": 6, "portfolio_position_rows": 18},
+    )
+
+    state = _state(
+        smoke=False,
+        context={
+            "trading_days": ["2026-04-01", "2026-04-02"],
+            "levels_max_after": dt.date(2026, 4, 2),
+            "max_portfolio_before": dt.date(2026, 4, 1),
+            "max_portfolio_position_before": dt.date(2026, 4, 1),
+            "max_portfolio_opt_inputs_before": dt.date(2026, 4, 1),
+            "max_portfolio_complete_before": dt.date(2026, 4, 1),
+        },
+    )
+
+    result = runtime.portfolio_analytics(state)
+
+    assert result["status"] == "OK"
+    assert captured["argv"][captured["argv"].index("--start") + 1] == "2026-04-02"
+    assert result["context"]["portfolio_opt_inputs_max_after"] == dt.date(2026, 4, 1)
+    assert result["context"]["portfolio_opt_inputs_required_date"] == dt.date(2026, 4, 1)
+
+
+def test_portfolio_analytics_fails_when_latest_rebalance_inputs_missing(monkeypatch, tmp_path):
+    runtime = SCIdxPipelineRuntime(
+        report_dir=tmp_path,
+        telemetry_dir=tmp_path / "telemetry",
+        state_store=_FakeStore(),
+    )
+
+    monkeypatch.setattr(runtime, "_load_portfolio_analytics_module", lambda: SimpleNamespace(main=lambda argv: 0))
+    monkeypatch.setattr(
+        "index_engine.orchestration.db_portfolio_analytics.fetch_portfolio_analytics_max_date",
+        lambda: dt.date(2026, 4, 2),
+    )
+    monkeypatch.setattr(
+        "index_engine.orchestration.db_portfolio_analytics.fetch_portfolio_position_max_date",
+        lambda: dt.date(2026, 4, 2),
+    )
+    monkeypatch.setattr(
+        "index_engine.orchestration.db_portfolio_analytics.fetch_portfolio_opt_inputs_max_date",
+        lambda: dt.date(2026, 4, 1),
+    )
+    monkeypatch.setattr(
+        "index_engine.orchestration.db_portfolio_analytics.fetch_latest_required_portfolio_opt_inputs_date",
+        lambda end_date: dt.date(2026, 4, 2),
+    )
+
+    state = _state(
+        smoke=False,
+        context={
+            "trading_days": ["2026-04-01", "2026-04-02"],
+            "levels_max_after": dt.date(2026, 4, 2),
+            "max_portfolio_before": dt.date(2026, 4, 1),
+            "max_portfolio_position_before": dt.date(2026, 4, 1),
+            "max_portfolio_opt_inputs_before": dt.date(2026, 4, 1),
+            "max_portfolio_complete_before": dt.date(2026, 4, 1),
+        },
+    )
+
+    result = runtime.portfolio_analytics(state)
+
+    assert result["status"] == "FAILED"
+    assert result["detail"] == "portfolio_opt_inputs_not_advanced"
+    assert "required_opt_inputs_date=2026-04-02" in result["error"]
 
 
 def test_calc_index_main_accepts_optional_argv():


### PR DESCRIPTION
## Summary
- fix SC_IDX portfolio completion/freshness logic so rebalance-scoped optimizer inputs do not block healthy non-rebalance days
- keep portfolio failures explicit when optimizer inputs are actually missing for the latest required rebalance date
- recover VM1 production and verify SC_IDX pipeline succeeds through 2026-04-02

## Changes
- add `fetch_latest_required_portfolio_opt_inputs_date()` and use it to evaluate the latest rebalance date that optimizer inputs must cover
- change `fetch_portfolio_completion_max_date()` to treat portfolio analytics/positions as the daily completion floor and only hold completion back when optimizer inputs lag a required rebalance date
- change the `portfolio_analytics` LangGraph stage validator to compare optimizer inputs against the latest required rebalance date instead of `max_level_date`
- add regression tests for non-rebalance success and true rebalance-missing failure cases

## Testing
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 .venv/bin/python -m pytest --noconftest -q tests/test_portfolio_analytics_v1.py tests/test_db_portfolio_analytics.py tests/test_run_pipeline.py`
- `sudo -n systemd-run --wait --pipe --collect --service-type=exec --property User=opc --property WorkingDirectory=/home/opc/Sustainacore --property Environment=PYTHONPATH=/home/opc/Sustainacore --property Environment=PYTHONUNBUFFERED=1 --property Environment=TNS_ADMIN=/opt/adb_wallet --property EnvironmentFile=/etc/sustainacore/db.env --property EnvironmentFile=/etc/sustainacore/index.env --property EnvironmentFile=/etc/sustainacore-ai/secrets.env --property RuntimeMaxSec=1800 /home/opc/Sustainacore/.venv/bin/python /home/opc/Sustainacore/tools/index_engine/run_pipeline.py --restart`

## Evidence
- Production root cause: `SC_IDX_PORTFOLIO_ANALYTICS_DAILY` and `SC_IDX_PORTFOLIO_POSITION_DAILY` had advanced to `2026-04-02`, but `SC_IDX_PORTFOLIO_OPT_INPUTS` correctly remained at rebalance date `2026-04-01`; the stage validator incorrectly required optimizer inputs to advance to `max_level_date`
- Oracle verification after deploy:
  - `SC_IDX_PORTFOLIO_OPT_INPUTS = 2026-04-01`
  - `SC_IDX_PORTFOLIO_ANALYTICS_DAILY = 2026-04-02`
  - `SC_IDX_PORTFOLIO_POSITION_DAILY = 2026-04-02`
  - `SC_IDX_LEVELS = 2026-04-02`
  - `SC_IDX_STATS_DAILY = 2026-04-02`
- Latest production recovery run: `4f93c8bb-7024-4e83-9ca0-30fe95517484` finished `OK` at `2026-04-03T20:26:28Z`
- Latest `portfolio_analytics` stage row for that run is `SKIP` with `portfolio_up_to_date=2026-04-02`
- Latest runtime identity after deploy: `repo_root=/opt/sustainacore-sc-idx-bc273c5f00ef`, `repo_head=bc273c5`

## Notes / Follow-ups
- `/opt/sustainacore-ai` on VM1 currently has unrelated local modifications, so I used a surgical SC_IDX scheduler release deploy instead of the standard VM1 git deploy script for this incident
- This fix keeps rebalance-day optimizer input gaps as a hard failure; it only stops false failures on non-rebalance days