### PR TITLE
Fix portfolio analytics catch-up window

### DIFF
--- a/app/index_engine/orchestration.py
+++ b/app/index_engine/orchestration.py
@@ -1346,21 +1346,15 @@ class SCIdxPipelineRuntime:
         if max_level_date is None:
             return {"status": "SKIP", "detail": "no_levels_available"}
 
-        portfolio_max_before = (
-            _coerce_date(context.get("max_portfolio_before"))
-            or db_portfolio_analytics.fetch_portfolio_analytics_max_date()
-        )
-        portfolio_position_before = (
-            _coerce_date(context.get("max_portfolio_position_before"))
-            or db_portfolio_analytics.fetch_portfolio_position_max_date()
-        )
-        portfolio_opt_inputs_before = (
-            _coerce_date(context.get("max_portfolio_opt_inputs_before"))
-            or db_portfolio_analytics.fetch_portfolio_opt_inputs_max_date()
-        )
-        portfolio_complete_before = (
-            _coerce_date(context.get("max_portfolio_complete_before"))
-            or db_portfolio_analytics.fetch_portfolio_completion_max_date()
+        # Refresh these directly from Oracle at stage time. determine_target_dates
+        # runs before calc_index, so context-cached "before" values can miss a
+        # rebalance date that calc_index exposes later in the same run.
+        portfolio_max_before = db_portfolio_analytics.fetch_portfolio_analytics_max_date()
+        portfolio_position_before = db_portfolio_analytics.fetch_portfolio_position_max_date()
+        portfolio_opt_inputs_before = db_portfolio_analytics.fetch_portfolio_opt_inputs_max_date()
+        portfolio_complete_before = db_portfolio_analytics.fetch_portfolio_completion_max_date()
+        portfolio_opt_inputs_required_date = db_portfolio_analytics.fetch_latest_required_portfolio_opt_inputs_date(
+            max_level_date
         )
         if portfolio_complete_before is not None and portfolio_complete_before >= max_level_date:
             return {
@@ -1376,6 +1370,11 @@ class SCIdxPipelineRuntime:
         start_day = _select_next_missing_trading_day(trading_days, portfolio_complete_before) if trading_days else None
         if start_day is None:
             start_day = max(BASE_DATE, max_level_date)
+        if portfolio_opt_inputs_required_date is not None and (
+            portfolio_opt_inputs_before is None
+            or portfolio_opt_inputs_before < portfolio_opt_inputs_required_date
+        ):
+            start_day = min(start_day, portfolio_opt_inputs_required_date)
 
         try:
             code = build_module.main(
@@ -1410,9 +1409,6 @@ class SCIdxPipelineRuntime:
         portfolio_max_after = db_portfolio_analytics.fetch_portfolio_analytics_max_date()
         portfolio_position_max_after = db_portfolio_analytics.fetch_portfolio_position_max_date()
         portfolio_opt_inputs_max_after = db_portfolio_analytics.fetch_portfolio_opt_inputs_max_date()
-        portfolio_opt_inputs_required_date = db_portfolio_analytics.fetch_latest_required_portfolio_opt_inputs_date(
-            max_level_date
-        )
         if portfolio_max_after is None or portfolio_max_after < max_level_date:
             return {
                 "status": "FAILED",
@@ -1462,6 +1458,7 @@ class SCIdxPipelineRuntime:
             "context": {
                 "portfolio_start_date": start_day,
                 "portfolio_end_date": max_level_date,
+                "portfolio_complete_before": portfolio_complete_before,
                 "portfolio_max_after": portfolio_max_after,
                 "portfolio_position_max_after": portfolio_position_max_after,
                 "portfolio_opt_inputs_max_after": portfolio_opt_inputs_max_after,
@@ -1929,6 +1926,10 @@ def _refresh_pipeline_report(state: PipelineGraphState, runtime: PipelineRuntime
     report_context, snapshot_warnings = _hydrate_report_context_with_health_snapshot(
         next_state,
         dict(next_state.get("context") or {}),
+    )
+    report_context.setdefault(
+        "telemetry_path",
+        str(runtime.telemetry_dir / f"sc_idx_pipeline_{next_state['run_id']}.json"),
     )
     for warning in snapshot_warnings:
         _append_warning(next_state, warning)

--- a/tests/test_run_pipeline.py
+++ b/tests/test_run_pipeline.py
@@ -468,6 +468,12 @@ def test_determine_target_dates_keeps_calc_and_portfolio_work_when_downstream_ta
 
 def test_portfolio_analytics_reruns_when_positions_lag(monkeypatch, tmp_path):
     captured = {}
+    current = {
+        "analytics": dt.date(2026, 4, 1),
+        "positions": dt.date(2026, 3, 31),
+        "opt_inputs": dt.date(2026, 4, 1),
+        "complete": dt.date(2026, 3, 31),
+    }
     runtime = SCIdxPipelineRuntime(
         report_dir=tmp_path,
         telemetry_dir=tmp_path / "telemetry",
@@ -476,17 +482,26 @@ def test_portfolio_analytics_reruns_when_positions_lag(monkeypatch, tmp_path):
 
     def _fake_main(argv):
         captured["argv"] = argv
+        current["positions"] = dt.date(2026, 4, 1)
+        current["complete"] = dt.date(2026, 4, 1)
         return 0
 
     monkeypatch.setattr(runtime, "_load_portfolio_analytics_module", lambda: SimpleNamespace(main=_fake_main))
-    monkeypatch.setattr("index_engine.orchestration.db_portfolio_analytics.fetch_portfolio_analytics_max_date", lambda: dt.date(2026, 4, 1))
+    monkeypatch.setattr(
+        "index_engine.orchestration.db_portfolio_analytics.fetch_portfolio_analytics_max_date",
+        lambda: current["analytics"],
+    )
     monkeypatch.setattr(
         "index_engine.orchestration.db_portfolio_analytics.fetch_portfolio_position_max_date",
-        lambda: dt.date(2026, 4, 1),
+        lambda: current["positions"],
     )
     monkeypatch.setattr(
         "index_engine.orchestration.db_portfolio_analytics.fetch_portfolio_opt_inputs_max_date",
-        lambda: dt.date(2026, 4, 1),
+        lambda: current["opt_inputs"],
+    )
+    monkeypatch.setattr(
+        "index_engine.orchestration.db_portfolio_analytics.fetch_portfolio_completion_max_date",
+        lambda: current["complete"],
     )
     monkeypatch.setattr(
         "index_engine.orchestration.db_portfolio_analytics.fetch_latest_required_portfolio_opt_inputs_date",
@@ -518,6 +533,12 @@ def test_portfolio_analytics_reruns_when_positions_lag(monkeypatch, tmp_path):
 
 def test_portfolio_analytics_accepts_rebalance_scoped_optimizer_inputs(monkeypatch, tmp_path):
     captured = {}
+    current = {
+        "analytics": dt.date(2026, 4, 1),
+        "positions": dt.date(2026, 4, 1),
+        "opt_inputs": dt.date(2026, 4, 1),
+        "complete": dt.date(2026, 4, 1),
+    }
     runtime = SCIdxPipelineRuntime(
         report_dir=tmp_path,
         telemetry_dir=tmp_path / "telemetry",
@@ -526,20 +547,27 @@ def test_portfolio_analytics_accepts_rebalance_scoped_optimizer_inputs(monkeypat
 
     def _fake_main(argv):
         captured["argv"] = argv
+        current["analytics"] = dt.date(2026, 4, 2)
+        current["positions"] = dt.date(2026, 4, 2)
+        current["complete"] = dt.date(2026, 4, 2)
         return 0
 
     monkeypatch.setattr(runtime, "_load_portfolio_analytics_module", lambda: SimpleNamespace(main=_fake_main))
     monkeypatch.setattr(
         "index_engine.orchestration.db_portfolio_analytics.fetch_portfolio_analytics_max_date",
-        lambda: dt.date(2026, 4, 2),
+        lambda: current["analytics"],
     )
     monkeypatch.setattr(
         "index_engine.orchestration.db_portfolio_analytics.fetch_portfolio_position_max_date",
-        lambda: dt.date(2026, 4, 2),
+        lambda: current["positions"],
     )
     monkeypatch.setattr(
         "index_engine.orchestration.db_portfolio_analytics.fetch_portfolio_opt_inputs_max_date",
-        lambda: dt.date(2026, 4, 1),
+        lambda: current["opt_inputs"],
+    )
+    monkeypatch.setattr(
+        "index_engine.orchestration.db_portfolio_analytics.fetch_portfolio_completion_max_date",
+        lambda: current["complete"],
     )
     monkeypatch.setattr(
         "index_engine.orchestration.db_portfolio_analytics.fetch_latest_required_portfolio_opt_inputs_date",
@@ -612,6 +640,71 @@ def test_portfolio_analytics_fails_when_latest_rebalance_inputs_missing(monkeypa
     assert result["status"] == "FAILED"
     assert result["detail"] == "portfolio_opt_inputs_not_advanced"
     assert "required_opt_inputs_date=2026-04-02" in result["error"]
+
+
+def test_portfolio_analytics_reloads_completion_before_choosing_start_day(monkeypatch, tmp_path):
+    captured = {}
+    current = {
+        "analytics": dt.date(2026, 4, 6),
+        "positions": dt.date(2026, 4, 6),
+        "opt_inputs": dt.date(2026, 4, 1),
+        "complete": dt.date(2026, 4, 1),
+    }
+    runtime = SCIdxPipelineRuntime(
+        report_dir=tmp_path,
+        telemetry_dir=tmp_path / "telemetry",
+        state_store=_FakeStore(),
+    )
+
+    def _fake_main(argv):
+        captured["argv"] = argv
+        current["opt_inputs"] = dt.date(2026, 4, 2)
+        current["complete"] = dt.date(2026, 4, 6)
+        return 0
+
+    monkeypatch.setattr(runtime, "_load_portfolio_analytics_module", lambda: SimpleNamespace(main=_fake_main))
+    monkeypatch.setattr(
+        "index_engine.orchestration.db_portfolio_analytics.fetch_portfolio_analytics_max_date",
+        lambda: current["analytics"],
+    )
+    monkeypatch.setattr(
+        "index_engine.orchestration.db_portfolio_analytics.fetch_portfolio_position_max_date",
+        lambda: current["positions"],
+    )
+    monkeypatch.setattr(
+        "index_engine.orchestration.db_portfolio_analytics.fetch_portfolio_opt_inputs_max_date",
+        lambda: current["opt_inputs"],
+    )
+    monkeypatch.setattr(
+        "index_engine.orchestration.db_portfolio_analytics.fetch_portfolio_completion_max_date",
+        lambda: current["complete"],
+    )
+    monkeypatch.setattr(
+        "index_engine.orchestration.db_portfolio_analytics.fetch_latest_required_portfolio_opt_inputs_date",
+        lambda end_date: dt.date(2026, 4, 2),
+    )
+    monkeypatch.setattr(
+        "index_engine.orchestration._query_portfolio_counts",
+        lambda start_date, end_date: {"portfolio_analytics_rows": 12, "portfolio_position_rows": 300},
+    )
+
+    state = _state(
+        smoke=False,
+        context={
+            "trading_days": ["2026-04-02", "2026-04-06"],
+            "levels_max_after": dt.date(2026, 4, 6),
+            "max_portfolio_before": dt.date(2026, 4, 2),
+            "max_portfolio_position_before": dt.date(2026, 4, 2),
+            "max_portfolio_opt_inputs_before": dt.date(2026, 4, 1),
+            "max_portfolio_complete_before": dt.date(2026, 4, 2),
+        },
+    )
+
+    result = runtime.portfolio_analytics(state)
+
+    assert result["status"] == "OK"
+    assert captured["argv"][captured["argv"].index("--start") + 1] == "2026-04-02"
+    assert result["context"]["portfolio_complete_before"] == dt.date(2026, 4, 1)
 
 
 def test_calc_index_main_accepts_optional_argv():
@@ -1003,3 +1096,35 @@ def test_clean_skip_alerts_are_not_sent(monkeypatch, tmp_path):
 
     assert calls["sent"] == 0
     assert final_state["alert"]["decision"] == "skipped"
+
+
+def test_refresh_pipeline_report_preseeds_telemetry_path(tmp_path):
+    runtime = SmokePipelineRuntime(smoke_scenario="failed", report_dir=tmp_path, state_store=_FakeStore())
+    state = _state(
+        smoke=False,
+        terminal_status="failed",
+        status_reason="portfolio_analytics",
+        context={
+            "ended_at": "2026-01-07T00:05:00+00:00",
+            "expected_target_date": "2026-01-07",
+            "levels_max_after": "2026-01-07",
+            "stats_max_after": "2026-01-07",
+            "portfolio_max_after": "2026-01-05",
+            "portfolio_position_max_after": "2026-01-07",
+        },
+        stage_results={
+            "portfolio_analytics": {
+                "stage": "portfolio_analytics",
+                "status": "FAILED",
+                "detail": "portfolio_opt_inputs_not_advanced",
+                "counts": {},
+                "warnings": [],
+                "attempts": 1,
+                "duration_sec": 1.2,
+            }
+        },
+    )
+
+    refreshed = orchestration._refresh_pipeline_report(state, runtime)
+
+    assert refreshed["report"]["artifact_paths"]["telemetry_path"].endswith("sc_idx_pipeline_run-test.json")


### PR DESCRIPTION
## Summary
- fix the portfolio analytics catch-up window so the stage reloads current Oracle completion state after `calc_index`
- stop stale pre-calc planner context from skipping a missing rebalance window and re-failing with `portfolio_opt_inputs_not_advanced`
- preseed the pipeline report telemetry path so failed early reports no longer show `telemetry_path: n/a`

## Changes
- reload `max_portfolio_*` and `portfolio_opt_inputs_required_date` from Oracle inside `portfolio_analytics()` before selecting `start_day`
- backshift the portfolio catch-up start date to the latest required optimizer-input date when that rebalance window is still missing
- add regressions for the stale-context catch-up bug and for report telemetry path prepopulation

## Testing
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 .venv/bin/python -m pytest --noconftest -q tests/test_db_portfolio_analytics.py tests/test_run_pipeline.py`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 .venv/bin/python -m pytest --noconftest -q tests/test_portfolio_analytics_v1.py tests/test_db_portfolio_analytics.py tests/test_run_pipeline.py`

## Evidence
- Runtime evidence before fix: failing run `d41adc04-e46c-41e7-a332-c90b5e38ff48` chose `start_day=2026-04-06` while `required_opt_inputs_date=2026-04-02` and `max_portfolio_opt_inputs=2026-04-01`, so the missing rebalance window was skipped and the stage re-failed.
- Runtime evidence after recovery: successful run `d8072cc6-89c8-49c7-9465-90ba2ccb6c89` refreshed `portfolio_start_date=2026-04-02`, `portfolio_end_date=2026-04-06`, `portfolio_opt_inputs_max_after=2026-04-02`, and advanced portfolio analytics to `2026-04-06`.
- Production deploy: VM1 scheduler checkout now runs commit `6d524d3` from `/opt/sustainacore-sc-idx-6d524d3004f3` via `/home/opc/Sustainacore`.
- Latest Oracle state after deploy: `SC_IDX_PORTFOLIO_OPT_INPUTS=2026-04-02`, `SC_IDX_PORTFOLIO_ANALYTICS_DAILY=2026-04-06`, `SC_IDX_PORTFOLIO_POSITION_DAILY=2026-04-06`, `SC_IDX_LEVELS=2026-04-06`, `SC_IDX_STATS_DAILY=2026-04-06`, `SC_IDX_PRICES_CANON=2026-04-06`.

## Notes / Follow-ups
- A manual `--restart` verification run after deploy hit an unrelated same-day `completeness_check` failure (`canon_lag`) for `2026-04-07`; it did not regress portfolio analytics and did not change the already healthy `2026-04-06` production state.
