### PR TITLE
Enforce Joao GitHub identity for Codex CLI

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -257,6 +257,19 @@ dmesg -T | egrep -i "oom|out of memory|killed process" | tail -n 60
 - Migration tool: `tools/db_migrations/migrate_fi_to_fisv.py` (dry-run default, `--apply` to write).
 - Rollback via backup tables `SC_BAK_FI_FISV_*` created per apply run.
 
+## GitHub Identity and Contribution Attribution
+- The only allowed GitHub login for write actions is `joaotovolli`.
+- Codex CLI must never create commits, branches, pushes, Pull Requests, Pull Request updates, GitHub comments, or other GitHub write actions using any external Codex, bot, generic, or non-`joaotovolli` GitHub account.
+- Before `git checkout -b`, `git switch -c`, `git commit`, `git push`, `gh pr create`, `gh pr edit`, `gh pr comment`, or any other Git/GitHub write action, Codex must run `bash scripts/verify_github_identity.sh`.
+- If `gh api user -q .login` does not return `joaotovolli`, Codex may make local file edits only and must stop before Git/GitHub write actions.
+- Git author must be `Joao Tovolli`.
+- Git email must be `225354763+joaotovolli@users.noreply.github.com`.
+- Every Pull Request must be opened with `gh` authenticated as `joaotovolli`.
+- Never add `Co-authored-by` trailers for Codex.
+- Never add `Generated-by Codex`, `Authored-by Codex`, or similar generated-by/authored-by trailers.
+- The final report for PR work must include authenticated GitHub user, local git author, latest commit author, latest commit committer, and Pull Request author when a PR is created.
+- Do not print GitHub tokens, credentials, or GitHub CLI host configuration while verifying identity.
+
 ## GitHub Hygiene: Commits & PRs
 - Commit messages: imperative subject, <= 72 chars, no trailing period.
 - Prefer logical commits for distinct changes; avoid noisy commits like "WIP", "fix", "temp".

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -1,5 +1,11 @@
 # Sustainacore Operations Guide
 
+## GitHub identity and contribution attribution
+- Follow the mandatory identity gate in [AGENTS.md](../AGENTS.md#github-identity-and-contribution-attribution) before any Git or GitHub write action.
+- The only allowed GitHub login for write actions is `joaotovolli`; Codex CLI must stop before commits, branches, pushes, Pull Requests, PR updates, or GitHub comments if `bash scripts/verify_github_identity.sh` does not pass.
+- Git author identity must be `Joao Tovolli <225354763+joaotovolli@users.noreply.github.com>`, and PRs must be opened with `gh` authenticated as `joaotovolli`.
+- Do not add Codex co-author, generated-by, authored-by, bot, or generic attribution trailers, and never print tokens, credentials, or GitHub CLI host configuration while verifying identity.
+
 ## Embedding parity
 - `EMBED_MODEL_NAME` is the single source of truth for the embedding model used by the service. The previous `OLLAMA_EMBED_MODEL` is read only for backwards compatibility.
 - At worker start a parity probe reads the Oracle vector column metadata. Dimension or model mismatches log a warning by default.

--- a/scripts/verify_github_identity.sh
+++ b/scripts/verify_github_identity.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+EXPECTED_GH_USER="joaotovolli"
+EXPECTED_GIT_NAME="Joao Tovolli"
+EXPECTED_GIT_EMAIL="225354763+joaotovolli@users.noreply.github.com"
+
+if env | cut -d= -f1 | grep -Eq '^(GH_TOKEN|GITHUB_TOKEN)$'; then
+  echo "WARNING: GH_TOKEN or GITHUB_TOKEN is present in the environment. If identity validation fails, unset token override variables and retry."
+fi
+
+ACTUAL_GH_USER="$(gh api user -q .login 2>/dev/null || true)"
+
+if [ "${ACTUAL_GH_USER}" != "${EXPECTED_GH_USER}" ]; then
+  echo "BLOCKED: GitHub CLI is authenticated as '${ACTUAL_GH_USER}', expected '${EXPECTED_GH_USER}'."
+  echo "User action required if browser approval is needed: gh auth login -h github.com --git-protocol https --scopes repo,workflow,read:org --web"
+  exit 2
+fi
+
+GITHUB_ID="$(gh api user -q .id)"
+GITHUB_LOGIN="$(gh api user -q .login)"
+GITHUB_NOREPLY_EMAIL="${GITHUB_ID}+${GITHUB_LOGIN}@users.noreply.github.com"
+
+if [ "${GITHUB_NOREPLY_EMAIL}" != "${EXPECTED_GIT_EMAIL}" ]; then
+  echo "BLOCKED: GitHub noreply email is '${GITHUB_NOREPLY_EMAIL}', expected '${EXPECTED_GIT_EMAIL}'."
+  exit 2
+fi
+
+git config user.name "${EXPECTED_GIT_NAME}"
+git config user.email "${EXPECTED_GIT_EMAIL}"
+
+ACTUAL_GIT_NAME="$(git config --get user.name || true)"
+ACTUAL_GIT_EMAIL="$(git config --get user.email || true)"
+
+echo "GitHub authenticated user: ${GITHUB_LOGIN}"
+echo "Git author name: ${ACTUAL_GIT_NAME}"
+echo "Git author email: ${ACTUAL_GIT_EMAIL}"
+
+if [ "${ACTUAL_GIT_NAME}" != "${EXPECTED_GIT_NAME}" ]; then
+  echo "BLOCKED: git user.name is not ${EXPECTED_GIT_NAME}."
+  exit 2
+fi
+
+if [ "${ACTUAL_GIT_EMAIL}" != "${EXPECTED_GIT_EMAIL}" ]; then
+  echo "BLOCKED: git user.email is not ${EXPECTED_GIT_EMAIL}."
+  exit 2
+fi


### PR DESCRIPTION
## Summary
- Enforce `joaotovolli` as the only allowed GitHub identity for Codex CLI write actions.
- Add a local identity verification script for GitHub auth and git author configuration.

## Changes
- Added mandatory GitHub identity and contribution attribution rules to AGENTS.md.
- Added operations guidance that references the mandatory identity gate.
- Added scripts/verify_github_identity.sh to validate `gh` identity, noreply email, and local git author config.

## Testing
- `bash scripts/verify_github_identity.sh`
- `git diff --cached --check`
- `git show -s --format='Author: %an <%ae>%nCommitter: %cn <%ce>%nSubject: %s' HEAD`

## Evidence
- Expected GitHub user: `joaotovolli`.
- Expected git author: `Joao Tovolli <225354763+joaotovolli@users.noreply.github.com>`.
- Codex CLI is now explicitly blocked from using Codex, bot, generic, or external GitHub identities for write actions.
- No GitHub tokens or host configuration were printed.

## Notes
Codex may make local file edits, but Git/GitHub write actions are allowed only after identity verification passes.
