### PR TITLE
Fix TECH100 factor model rebalance continuity

### DIFF
--- a/app/index_engine/portfolio_analytics_v1.py
+++ b/app/index_engine/portfolio_analytics_v1.py
@@ -225,6 +225,33 @@ def normalize_weights(raw_weights: Mapping[str, float]) -> dict[str, float]:
     return {ticker: weight / total for ticker, weight in cleaned.items() if weight > 0}
 
 
+def _investable_weights(
+    target_weights: Mapping[str, float],
+    anchor_prices: Mapping[str, float],
+) -> dict[str, float]:
+    return normalize_weights(
+        {
+            ticker: weight
+            for ticker, weight in target_weights.items()
+            if _safe_float(anchor_prices.get(ticker)) not in (None, 0)
+        }
+    )
+
+
+def _valuation_price(
+    ticker: str,
+    prices_now: Mapping[str, float],
+    prev_prices: Mapping[str, float],
+) -> float | None:
+    current_price = _safe_float(prices_now.get(ticker))
+    if current_price not in (None, 0):
+        return current_price
+    previous_price = _safe_float(prev_prices.get(ticker))
+    if previous_price not in (None, 0):
+        return previous_price
+    return None
+
+
 def compute_factor_history(
     trade_days: Sequence[_dt.date],
     price_by_date: Mapping[_dt.date, Mapping[str, float]],
@@ -588,18 +615,24 @@ def build_model_path(
             anchor_date = prev_trade or trade_date
             anchor_level = levels_by_date.get(prev_trade, benchmark_levels.get(anchor_date, benchmark_levels[trade_days[0]]))
             anchor_prices = price_by_date.get(anchor_date, {})
+            investable_weights = _investable_weights(target_weights, anchor_prices)
+            if not investable_weights:
+                if current_shares:
+                    current_rebalance = trade_date
+                else:
+                    prev_trade = trade_date
+                continue
             current_shares = {
                 ticker: anchor_level * weight / anchor_prices[ticker]
-                for ticker, weight in target_weights.items()
-                if anchor_prices.get(ticker) not in (None, 0)
+                for ticker, weight in investable_weights.items()
             }
             current_rebalance = trade_date
 
         prices_now = price_by_date.get(trade_date, {})
         market_values = {
-            ticker: shares * prices_now[ticker]
+            ticker: shares * valuation_price
             for ticker, shares in current_shares.items()
-            if prices_now.get(ticker) not in (None, 0)
+            if (valuation_price := _valuation_price(ticker, prices_now, prev_prices)) is not None
         }
         total_market_value = sum(market_values.values())
         if total_market_value <= 0:

--- a/tests/test_portfolio_analytics_v1.py
+++ b/tests/test_portfolio_analytics_v1.py
@@ -8,6 +8,7 @@ from app.index_engine.portfolio_analytics_v1 import (
     OfficialDailyRow,
     OfficialPositionRow,
     PriceRow,
+    build_model_path,
     build_model_target_weights,
     build_portfolio_outputs,
     compute_factor_history,
@@ -39,6 +40,28 @@ def test_build_model_target_weights_supports_equal_and_governance_tilt():
     assert tilted["AAA"] > benchmark["AAA"]
     assert tilted["BBB"] < benchmark["BBB"]
     assert pytest.approx(sum(tilted.values())) == 1.0
+
+
+def test_official_and_equal_weight_match_when_benchmark_is_equal_weighted():
+    benchmark = {"AAA": 0.25, "BBB": 0.25, "CCC": 0.25, "DDD": 0.25}
+    signals = {ticker: 1.0 for ticker in benchmark}
+
+    official = build_model_target_weights(
+        model_code="TECH100",
+        benchmark_weights=benchmark,
+        governance_scores=signals,
+        momentum_scores=signals,
+        low_vol_scores=signals,
+    )
+    equal = build_model_target_weights(
+        model_code="TECH100_EQ",
+        benchmark_weights=benchmark,
+        governance_scores=signals,
+        momentum_scores=signals,
+        low_vol_scores=signals,
+    )
+
+    assert official == pytest.approx(equal)
 
 
 def test_compute_factor_history_uses_trailing_windows():
@@ -190,3 +213,140 @@ def test_build_portfolio_outputs_generates_rows_for_all_models():
         if row["model_code"] == "TECH100_EQ" and row["trade_date"] == trade_days[0]
     ]
     assert {row["ticker"]: row["model_weight"] for row in eq_rows} == {"AAA": 0.5, "BBB": 0.5}
+
+
+def test_model_path_chain_links_rebalance_without_level_cliff():
+    trade_days = [
+        dt.date(2026, 3, 30),
+        dt.date(2026, 3, 31),
+        dt.date(2026, 4, 1),
+        dt.date(2026, 4, 2),
+    ]
+    benchmark_weights_by_date = {
+        trade_days[0]: {"AAA": 0.5, "BBB": 0.5},
+        trade_days[1]: {"AAA": 0.5, "BBB": 0.5},
+        trade_days[2]: {"AAA": 0.25, "BBB": 0.25, "CCC": 0.5},
+        trade_days[3]: {"AAA": 0.25, "BBB": 0.25, "CCC": 0.5},
+    }
+    price_by_date = {
+        trade_days[0]: {"AAA": 100.0, "BBB": 100.0, "CCC": 50.0},
+        trade_days[1]: {"AAA": 101.0, "BBB": 99.0, "CCC": 50.0},
+        trade_days[2]: {"AAA": 102.0, "BBB": 100.0, "CCC": 50.0},
+        trade_days[3]: {"AAA": 103.0, "BBB": 101.0, "CCC": 51.0},
+    }
+
+    levels, weights, *_ = build_model_path(
+        model_code="TECH100_EQ",
+        trade_days=trade_days,
+        rebalance_days=[trade_days[0], trade_days[2]],
+        benchmark_weights_by_date=benchmark_weights_by_date,
+        benchmark_levels={day: 1000.0 for day in trade_days},
+        active_port_by_trade={day: day for day in trade_days},
+        metadata_by_port_date={},
+        factor_history={day: {} for day in trade_days},
+        price_by_date=price_by_date,
+    )
+
+    expected_rebalance_return = ((102.0 / 101.0) + (100.0 / 99.0) + (50.0 / 50.0)) / 3.0 - 1.0
+    assert levels[trade_days[2]] == pytest.approx(levels[trade_days[1]] * (1.0 + expected_rebalance_return))
+    assert sum(weights[trade_days[2]].values()) == pytest.approx(1.0)
+
+
+def test_model_path_renormalizes_missing_anchor_prices_at_rebalance():
+    trade_days = [
+        dt.date(2026, 3, 31),
+        dt.date(2026, 4, 1),
+        dt.date(2026, 4, 2),
+    ]
+    benchmark_weights_by_date = {
+        trade_days[0]: {"AAA": 0.5, "BBB": 0.5},
+        trade_days[1]: {"AAA": 0.25, "BBB": 0.25, "CCC": 0.5},
+        trade_days[2]: {"AAA": 0.25, "BBB": 0.25, "CCC": 0.5},
+    }
+    price_by_date = {
+        trade_days[0]: {"AAA": 100.0, "BBB": 100.0},
+        trade_days[1]: {"AAA": 101.0, "BBB": 99.0, "CCC": 50.0},
+        trade_days[2]: {"AAA": 102.0, "BBB": 100.0, "CCC": 51.0},
+    }
+
+    levels, weights, *_ = build_model_path(
+        model_code="TECH100_EQ",
+        trade_days=trade_days,
+        rebalance_days=[trade_days[0], trade_days[1]],
+        benchmark_weights_by_date=benchmark_weights_by_date,
+        benchmark_levels={day: 1000.0 for day in trade_days},
+        active_port_by_trade={day: day for day in trade_days},
+        metadata_by_port_date={},
+        factor_history={day: {} for day in trade_days},
+        price_by_date=price_by_date,
+    )
+
+    assert levels[trade_days[1]] == pytest.approx(1000.0)
+    assert sum(weights[trade_days[1]].values()) == pytest.approx(1.0)
+    assert "CCC" not in weights[trade_days[1]]
+
+
+def test_model_path_carries_existing_holding_when_current_price_is_missing():
+    trade_days = [
+        dt.date(2026, 3, 31),
+        dt.date(2026, 4, 1),
+    ]
+    benchmark_weights_by_date = {
+        trade_days[0]: {"AAA": 0.5, "BBB": 0.5},
+        trade_days[1]: {"AAA": 0.5, "BBB": 0.5},
+    }
+    price_by_date = {
+        trade_days[0]: {"AAA": 100.0, "BBB": 100.0},
+        trade_days[1]: {"AAA": 102.0},
+    }
+
+    levels, weights, *_ = build_model_path(
+        model_code="TECH100_EQ",
+        trade_days=trade_days,
+        rebalance_days=[trade_days[0]],
+        benchmark_weights_by_date=benchmark_weights_by_date,
+        benchmark_levels={day: 1000.0 for day in trade_days},
+        active_port_by_trade={day: day for day in trade_days},
+        metadata_by_port_date={},
+        factor_history={day: {} for day in trade_days},
+        price_by_date=price_by_date,
+    )
+
+    assert levels[trade_days[1]] == pytest.approx(1010.0)
+    assert sum(weights[trade_days[1]].values()) == pytest.approx(1.0)
+
+
+def test_jan_1_non_trading_day_uses_previous_trade_for_rebalance_anchor():
+    trade_days = [
+        dt.date(2025, 12, 31),
+        dt.date(2026, 1, 2),
+        dt.date(2026, 1, 5),
+        dt.date(2026, 1, 6),
+    ]
+    benchmark_weights_by_date = {
+        trade_days[0]: {"AAA": 0.5, "BBB": 0.5},
+        trade_days[1]: {"AAA": 0.25, "BBB": 0.25, "CCC": 0.5},
+        trade_days[2]: {"AAA": 0.25, "BBB": 0.25, "CCC": 0.5},
+        trade_days[3]: {"AAA": 0.25, "BBB": 0.25, "CCC": 0.5},
+    }
+    price_by_date = {
+        trade_days[0]: {"AAA": 100.0, "BBB": 100.0, "CCC": 50.0},
+        trade_days[1]: {"AAA": 101.0, "BBB": 99.0, "CCC": 50.0},
+        trade_days[2]: {"AAA": 102.0, "BBB": 100.0, "CCC": 51.0},
+        trade_days[3]: {"AAA": 103.0, "BBB": 101.0, "CCC": 52.0},
+    }
+
+    levels, *_ = build_model_path(
+        model_code="TECH100_EQ",
+        trade_days=trade_days,
+        rebalance_days=[trade_days[0], trade_days[1]],
+        benchmark_weights_by_date=benchmark_weights_by_date,
+        benchmark_levels={day: 1000.0 for day in trade_days},
+        active_port_by_trade={day: day for day in trade_days},
+        metadata_by_port_date={},
+        factor_history={day: {} for day in trade_days},
+        price_by_date=price_by_date,
+    )
+
+    assert dt.date(2026, 1, 1) not in trade_days
+    assert levels[trade_days[1]] == pytest.approx(1000.0)


### PR DESCRIPTION
## Summary
- Fix TECH100 factor model rebalance continuity.
- Prevent artificial factor-model cliffs when rebalance target names lack valid anchor/current prices.
- Preserve chain-linked capital by renormalizing investable rebalance weights before constructing post-rebalance shares.

## Root cause
`app/index_engine/portfolio_analytics_v1.py::build_model_path` could silently exclude names without valid anchor prices at rebalance while leaving the remaining weights unnormalized. This turned missing anchor data into synthetic capital loss. Existing holdings with missing current prices could also be dropped from valuation, creating artificial level drops.

## Data path
- Official: SC_IDX_PORTFOLIO_ANALYTICS_DAILY / SC_IDX_PORTFOLIO_POSITION_DAILY, model TECH100.
- Equal Weight: model TECH100_EQ.
- Governance: model TECH100_GOV.
- Momentum: model TECH100_MOM.
- Low Vol: model TECH100_LOWVOL.
- Gov + Mom: model TECH100_GOV_MOM.
- Django page: portfolio data/view layer serializes backend model levels into the TECH100 portfolio page.

## Evidence
- Production page returned HTTP 200 and populated JSON.
- Around 2026-04-01, factor models showed large drops while Official did not.
- Synthetic missing-anchor reproducer showed the old logic could turn a normal positive move into a large artificial drop.
- After the fix, missing-anchor weights are renormalized over investable names and missing current valuation prices are carried safely.

## Testing
- `.venv/bin/python -m pytest tests/test_portfolio_analytics_v1.py -q` -> 8 passed.
- `cd website_django && DJANGO_SECRET_KEY=test ../.venv/bin/python manage.py test core.tests.test_tech100_portfolio_data --noinput` -> OK, 4 tests.
- `git diff --check` -> passed.

## Safety
- No destructive Oracle schema changes.
- No secrets printed.
- No provider/vendor names introduced.
- Requesting review before production deployment.