### PR TITLE
Improve website visibility and trust

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,31 @@
-# Sustainacore
+# SustainaCore
 
 ![CI](https://img.shields.io/badge/status-production_ready-blue)
 ![License](https://img.shields.io/badge/license-MIT-green)
 ![Contributions](https://img.shields.io/badge/contributions-welcome-brightgreen)
 
 ## Executive Summary
-Sustainacore delivers ESG knowledge retrieval and orchestration services that unify retrieval augmented generation, workflow automation, and governance tooling. This mono-repo tracks the production FastAPI surface, the Django public site served from VM2 (Nginx → Gunicorn), APEX integrations used for secondary/admin flows, database artifacts, and supporting infrastructure that keep the platform reliable for enterprise deployments.
+SustainaCore is a public AI governance research site at <https://sustainacore.org> that helps visitors compare company governance signals, track Global AI Regulation, ask grounded questions with Ask2, and verify methodology and corrections routes.
+
+This mono-repo contains the public Django website served from VM2, the VM1 API/RAG backend that powers Ask2 and data endpoints, operational tooling, tests, and documentation. The public site is intentionally transparent: methodology, sitemap coverage, corrections, and GitHub source context are visible so outsiders can inspect how the product is built and where the data comes from.
+
+### Key public modules
+- **Tech100 AI Ethics & Governance Index:** Company rankings, index performance, constituents, attribution, and methodology for AI governance and ethics signals.
+- **Global AI Regulation:** Jurisdiction-level AI regulation snapshots with instruments, milestones, and evidence coverage when the dataset is available.
+- **Ask2:** A public assistant that answers questions using the SustainaCore backend contract and returns user-facing answers with sources.
+- **News & Insights:** Curated updates around AI governance, transparency, regulation, and accountability.
+
+### Architecture summary
+- **VM2 website:** Django, templates, static assets, sitemap/robots endpoints, and public page rendering under `website_django/`.
+- **VM1 backend:** Retrieval/API services, Ask2 orchestration, Oracle-backed data access, and operational pipelines.
+- **Verification layer:** Django tests, pytest suites, GitHub Actions, sitemap/robots checks, preview deployment, and UI screenshot comparison workflows.
+
+### How to explore
+1. Open the live site: <https://sustainacore.org>.
+2. Start with the [Tech100 AI Ethics & Governance Index](https://sustainacore.org/tech100/index/) to compare companies.
+3. Review [Global AI Regulation](https://sustainacore.org/ai-regulation/) for jurisdiction coverage.
+4. Ask a question in [Ask2](https://sustainacore.org/ask2/).
+5. Verify the [Tech100 methodology](https://sustainacore.org/tech100/methodology/) and use [Corrections & Complaints](https://sustainacore.org/corrections/) for issues.
 
 ## Quick Start
 1. Clone the repository and create a Python virtual environment: `python3 -m venv .venv && source .venv/bin/activate`.
@@ -43,7 +63,7 @@ Sustainacore delivers ESG knowledge retrieval and orchestration services that un
 - Oracle APEX remains available for administrative/legacy workflows only; it is not the primary front-end.
 
 ## VM2 Django Website & Deployment
-- **What VM2 is:** VM2 runs the public Django website for Sustainacore, served by Gunicorn + Nginx. The repository is checked out on VM2 at `/opt/code/Sustainacore`, and the Django project lives in `website_django/`.
+- **What VM2 is:** VM2 runs the public Django website for SustainaCore, served by Gunicorn + Nginx. The repository is checked out on VM2 at `/opt/code/Sustainacore`, and the Django project lives in `website_django/`.
 - **Environment variables and secrets:** Gunicorn loads production settings from `/etc/sustainacore.env` via `EnvironmentFile`. A repo-local `.env.vm2` (present only on VM2 and never committed) is sourced by `deploy_vm2_website.sh` so that values such as `DJANGO_SECRET_KEY=***`, `BACKEND_API_BASE`, and `BACKEND_API_TOKEN` are available while running `manage.py` commands.
 - **Deployment flow:** The "Deploy VM2 Django Website" GitHub Action SSHs to VM2 and runs `bash ./deploy_vm2_website.sh`, making that script the single entry point. Manual deploys follow the same path:
   ```bash
@@ -90,7 +110,7 @@ The helper writes `/etc/systemd/system/sustainacore-ai.service.d/15-persona.conf
 - **Infrastructure tooling** for VM deployment, CI/CD hygiene, and data refresh workflows.
 
 ### Chat routing upgrades
-- `/ask2` now calls the smart router first when `ASK2_ENABLE_SMALLTALK=true`, returning a consistent "Hello! I can help with Sustainacore, TECH100, and ESG questions." greeting without invoking Gemini.
+- `/ask2` now calls the smart router first when `ASK2_ENABLE_SMALLTALK=true`, returning a consistent "Hello! I can help with SustainaCore, Tech100, and ESG questions." greeting without invoking Gemini.
 - Normal Q&A responses reformat sources via the router formatter, dedupe duplicate citations, and honor `ASK2_MAX_SOURCES` plus `ASK2_SOURCE_LABEL_MODE=concise` for compact labels.
 - The Gemini composer validates responses that arrive wrapped in fenced ```json code-blocks and reuses the parsed `answer`/`sources` whenever present.
 - A similarity guard enforces `SIMILARITY_FLOOR`: if the top retrieval score falls below the floor, the API responds with a clarifier instead of ungrounded sources and sets `meta.routing="low_conf"`.

--- a/website_django/ai_reg/templates/ai_reg/ai_regulation.html
+++ b/website_django/ai_reg/templates/ai_reg/ai_regulation.html
@@ -14,7 +14,7 @@
     <div class="section__header section__header--split ai-reg__page-header">
       <div>
         <span class="pill pill--soft">Global AI Regulation</span>
-        <h1>Regulatory coverage by jurisdiction</h1>
+        <h1>Global AI Regulation coverage by jurisdiction</h1>
         <p class="muted ai-reg__lede">Snapshots of AI regulation status, evidence coverage, and milestones across the world.</p>
       </div>
       <div class="ai-reg__page-brief">
@@ -22,6 +22,42 @@
         <p>Compare global coverage density, open a jurisdiction brief, and move directly into sourced instruments and milestones.</p>
       </div>
     </div>
+
+    <section class="card card--lined" aria-labelledby="ai-reg-fallback-heading">
+      <h2 class="h4" id="ai-reg-fallback-heading">Latest Global AI Regulation snapshot</h2>
+      {% if latest_as_of and fallback_rows %}
+        <p class="muted">
+          Server-rendered summary for <strong data-ai-reg-fallback-date>{{ latest_as_of }}</strong>.
+          The interactive atlas below uses the same snapshot selector when JavaScript is available.
+        </p>
+        <div class="table-wrapper table-wrap sc-table-wrap">
+          <table class="table table--wide sc-table" aria-label="Global AI Regulation crawlable summary">
+            <thead>
+              <tr>
+                <th class="text-left">Jurisdiction</th>
+                <th class="text-right">Instruments</th>
+                <th class="text-right">Primary verified</th>
+                <th class="text-right">Upcoming milestones</th>
+              </tr>
+            </thead>
+            <tbody>
+              {% for row in fallback_rows %}
+              <tr>
+                <td class="text-left">{{ row.name|default:row.iso2 }}</td>
+                <td class="text-right">{% firstof row.instruments_count row.instrument_count "0" %}</td>
+                <td class="text-right">{{ row.primary_verified_count|default:"0" }}</td>
+                <td class="text-right">{{ row.milestones_upcoming_count|default:"0" }}</td>
+              </tr>
+              {% endfor %}
+            </tbody>
+          </table>
+        </div>
+      {% elif latest_as_of and fallback_error %}
+        <p class="muted">A snapshot date is available for <strong>{{ latest_as_of }}</strong>, but the server-rendered regulation summary is temporarily unavailable. The page avoids showing partial jurisdiction counts.</p>
+      {% else %}
+        <p class="muted">Global AI Regulation data is temporarily unavailable. The page avoids inventing jurisdiction counts and will populate when the dataset is reachable.</p>
+      {% endif %}
+    </section>
 
     <div
       class="card ai-reg__card ai-reg__card--page"

--- a/website_django/ai_reg/tests/test_views.py
+++ b/website_django/ai_reg/tests/test_views.py
@@ -7,10 +7,24 @@ from ai_reg.data import AiRegDataError
 
 class AiRegViewsTests(TestCase):
     def test_ai_regulation_page_loads(self):
-        with mock.patch("ai_reg.views.ai_reg_data.fetch_as_of_dates", return_value=["2025-01-15"]):
+        heatmap = [
+            {
+                "iso2": "US",
+                "name": "United States",
+                "instruments_count": 2,
+                "primary_verified_count": 1,
+                "milestones_upcoming_count": 3,
+            }
+        ]
+        with (
+            mock.patch("ai_reg.views.ai_reg_data.fetch_as_of_dates", return_value=["2025-01-15"]),
+            mock.patch("ai_reg.views.ai_reg_data.fetch_heatmap", return_value=heatmap),
+        ):
             response = self.client.get("/ai-regulation/")
         self.assertEqual(response.status_code, 200)
         self.assertContains(response, "Global AI Regulation")
+        self.assertContains(response, "Latest Global AI Regulation snapshot")
+        self.assertContains(response, "United States")
 
     def test_as_of_dates_endpoint(self):
         with mock.patch("ai_reg.views.ai_reg_data.fetch_as_of_dates", return_value=["2025-01-15"]):
@@ -23,6 +37,17 @@ class AiRegViewsTests(TestCase):
             response = self.client.get("/ai-regulation/")
         self.assertEqual(response.status_code, 200)
         self.assertContains(response, "Global AI Regulation")
+        self.assertContains(response, "avoids inventing jurisdiction counts")
+
+    def test_ai_regulation_page_degrades_when_heatmap_is_unavailable(self):
+        with (
+            mock.patch("ai_reg.views.ai_reg_data.fetch_as_of_dates", return_value=["2025-01-15"]),
+            mock.patch("ai_reg.views.ai_reg_data.fetch_heatmap", side_effect=AiRegDataError("offline")),
+        ):
+            response = self.client.get("/ai-regulation/")
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, "2025-01-15")
+        self.assertContains(response, "server-rendered regulation summary is temporarily unavailable")
 
     def test_as_of_dates_endpoint_returns_503_when_data_is_unavailable(self):
         with mock.patch("ai_reg.views.ai_reg_data.fetch_as_of_dates", side_effect=AiRegDataError("offline")):

--- a/website_django/ai_reg/views.py
+++ b/website_django/ai_reg/views.py
@@ -37,9 +37,21 @@ def ai_regulation_page(request):
     except ai_reg_data.AiRegDataError:
         _log_ai_reg_data_issue("ai_regulation_page_oracle_fallback")
         as_of_dates = []
+    latest_as_of = as_of_dates[0] if as_of_dates else None
+    fallback_rows = []
+    fallback_error = False
+    parsed_latest = _parse_as_of(latest_as_of)
+    if parsed_latest:
+        try:
+            fallback_rows = ai_reg_data.fetch_heatmap(parsed_latest)[:8]
+        except ai_reg_data.AiRegDataError:
+            fallback_error = True
+            _log_ai_reg_data_issue("ai_regulation_page_heatmap_fallback")
     context = {
         "as_of_dates": as_of_dates,
-        "latest_as_of": as_of_dates[0] if as_of_dates else None,
+        "latest_as_of": latest_as_of,
+        "fallback_rows": fallback_rows,
+        "fallback_error": fallback_error,
     }
     return render(request, "ai_reg/ai_regulation.html", context)
 

--- a/website_django/core/tests/test_seo.py
+++ b/website_django/core/tests/test_seo.py
@@ -245,3 +245,37 @@ class SeoFoundationsTests(SimpleTestCase):
         content = response.content.decode("utf-8")
         self.assertIn('name="robots"', content)
         self.assertIn("noindex", content)
+
+    @mock.patch("core.views.ai_reg_data.fetch_as_of_dates", return_value=[])
+    @mock.patch("core.views.fetch_news_list", return_value={"items": [], "meta": {}, "error": None})
+    @mock.patch("core.views.fetch_tech100", return_value={"items": [], "error": None, "meta": {}})
+    @mock.patch("core.views.get_latest_trade_date", return_value=None)
+    def test_home_snippet_content_precedes_hidden_ui(
+        self, get_latest_trade_date, fetch_tech100, fetch_news_list, fetch_as_of_dates
+    ):
+        response = self.client.get(reverse("home"))
+
+        self.assertEqual(response.status_code, 200)
+        content = response.content.decode("utf-8")
+        self.assertIn("SustainaCore makes AI governance easier to verify.", content)
+        self.assertLess(
+            content.index("SustainaCore makes AI governance easier to verify."),
+            content.index("Manage your privacy preferences"),
+        )
+        self.assertIn('data-download-modal data-nosnippet', content)
+        self.assertIn('data-consent-modal data-nosnippet', content)
+        self.assertIn('data-consent-banner data-nosnippet', content)
+
+    @mock.patch("core.views.ai_reg_data.fetch_as_of_dates", return_value=[])
+    @mock.patch("core.views.fetch_news_list", return_value={"items": [], "meta": {}, "error": None})
+    @mock.patch("core.views.fetch_tech100", return_value={"items": [], "error": None, "meta": {}})
+    @mock.patch("core.views.get_latest_trade_date", return_value=None)
+    def test_home_title_and_description_explain_first_visit_journey(
+        self, get_latest_trade_date, fetch_tech100, fetch_news_list, fetch_as_of_dates
+    ):
+        response = self.client.get(reverse("home"))
+
+        self.assertEqual(response.status_code, 200)
+        content = response.content.decode("utf-8")
+        self.assertIn("<title>SustainaCore | AI governance data, regulation, and Ask2</title>", content)
+        self.assertIn("compare AI companies, track Global AI Regulation, ask Ask2", content)

--- a/website_django/core/tests/test_tech100_index_views.py
+++ b/website_django/core/tests/test_tech100_index_views.py
@@ -41,6 +41,10 @@ class Tech100IndexViewTests(SimpleTestCase):
         response = self.client.get(reverse("tech100_index"))
         self.assertEqual(response.status_code, 200)
         self.assertContains(response, "Performance &amp; Risk")
+        self.assertContains(response, "Data freshness and trust")
+        self.assertContains(response, "data-tech100-freshness-date")
+        self.assertContains(response, "latest Tech100 AI Ethics &amp; Governance Index date")
+        self.assertNotContains(response, "2025-03-04")
 
     @mock.patch.dict(os.environ, {"TECH100_UI_DATA_MODE": "fixture"})
     def test_overview_fixture_mode_has_data_markers(self):

--- a/website_django/core/tests/test_tech100_portfolio_views.py
+++ b/website_django/core/tests/test_tech100_portfolio_views.py
@@ -17,7 +17,7 @@ class Tech100PortfolioViewTests(SimpleTestCase):
     def test_portfolio_view_renders_fixture_mode(self, _index_latest_mock):
         response = self.client.get(reverse("tech100_portfolio"))
         self.assertEqual(response.status_code, 200)
-        self.assertContains(response, "TECH100 Portfolio Analytics")
+        self.assertContains(response, "Tech100 Portfolio Analytics")
         self.assertContains(response, "data-tech100-portfolio-has-data")
         self.assertContains(response, "Daily model tape")
         self.assertContains(response, "Analytics workspace")

--- a/website_django/core/tests/test_tech100_views.py
+++ b/website_django/core/tests/test_tech100_views.py
@@ -11,6 +11,9 @@ from core.auth import COOKIE_NAME
 
 
 class Tech100ViewTests(SimpleTestCase):
+    def setUp(self):
+        cache.clear()
+
     @mock.patch("core.views.fetch_news_list")
     @mock.patch("core.views.fetch_tech100")
     def test_home_renders_company_links(self, fetch_tech100, fetch_news_list):
@@ -101,6 +104,10 @@ class Tech100ViewTests(SimpleTestCase):
         section = content[related_idx:end_idx]
         matches = re.findall(r"/tech100/company/[A-Z0-9]+/", section)
         self.assertEqual(len(matches), 5)
+        self.assertIn("Alpha Inc Tech100 summary", content)
+        self.assertIn("Why this score?", content)
+        self.assertIn("/tech100/methodology/", content)
+        self.assertIn("/corrections/", content)
 
     @mock.patch("core.views.fetch_tech100")
     def test_tech100_view_renders_table_headers_and_details(self, fetch_mock):
@@ -135,7 +142,7 @@ class Tech100ViewTests(SimpleTestCase):
             "Governance Structure",
             "Regulatory Alignment",
             "Stakeholder Engagement",
-            "Composite AI Governance & Ethics Score",
+            "Composite AI Governance &amp; Ethics Score",
             "Details",
         ]:
             self.assertIn(header, content)

--- a/website_django/core/views.py
+++ b/website_django/core/views.py
@@ -1554,6 +1554,7 @@ def tech100_export(request):
     response["Content-Disposition"] = "attachment; filename=tech100.csv"
 
     headers = [
+        "PORT_DATE",
         "RANK_INDEX",
         "WEIGHT",
         "COMPANY_NAME",
@@ -1578,6 +1579,7 @@ def tech100_export(request):
 
         writer.writerow(
             [
+                _port_date_to_string(company.get("port_date") or company.get("port_date_str")),
                 company.get("rank_index") or "",
                 _format_port_weight(weight_value),
                 company.get("company_name") or "",

--- a/website_django/static/js/tech100-index.js
+++ b/website_django/static/js/tech100-index.js
@@ -103,7 +103,7 @@
       labels: data.map((point) => point.date),
       datasets: [
         {
-          label: "Tech100 AI Ethics & Gov Index",
+          label: "Tech100 AI Ethics & Governance Index",
           data: data.map((point) => point.level),
           borderColor: "#1c2b4a",
           borderWidth: 2,
@@ -208,7 +208,7 @@
         labels: levelsData.map((point) => point.date),
         datasets: [
           {
-            label: "Tech100 AI Ethics & Gov Index",
+            label: "Tech100 AI Ethics & Governance Index",
             data: levelsData.map((point) => point.level),
             borderColor: "#1c2b4a",
             borderWidth: 2,
@@ -305,7 +305,7 @@
 
     const levelChart = buildLineChart(
       levelCanvas,
-      "Tech100 AI Ethics & Gov Index",
+      "Tech100 AI Ethics & Governance Index",
       levels.map((point) => ({ date: point.date, value: point.level })),
       "#1c2b4a"
     );

--- a/website_django/static/js/tech100_company.js
+++ b/website_django/static/js/tech100_company.js
@@ -6,7 +6,7 @@
   if (!ticker) return;
 
   const METRICS = [
-    { key: "composite", label: "Composite AI Gov & Ethics" },
+    { key: "composite", label: "Composite AI Governance & Ethics" },
     { key: "transparency", label: "Transparency" },
     { key: "ethical_principles", label: "Ethical Principles" },
     { key: "governance_structure", label: "Governance Structure" },

--- a/website_django/static/js/telemetry.js
+++ b/website_django/static/js/telemetry.js
@@ -63,11 +63,13 @@
   const showBanner = () => {
     if (!banner) return;
     banner.hidden = false;
+    banner.setAttribute("aria-hidden", "false");
     setBodyBannerState(true);
   };
 
   const hideBanner = () => {
     if (!banner) return;
+    banner.setAttribute("aria-hidden", "true");
     banner.hidden = true;
     setBodyBannerState(false);
   };

--- a/website_django/templates/base.html
+++ b/website_django/templates/base.html
@@ -61,7 +61,7 @@
                     <nav class="nav nav--primary" aria-label="Primary">
                         <div class="nav__item nav__item--dropdown">
                             <div class="nav__dropdown-trigger {% if request.path|slice:':8' == '/tech100' %}is-active{% endif %}">
-                                <a href="/tech100/index/" class="nav__link nav__link--dropdown-link">Tech100 AI Index</a>
+                                <a href="/tech100/index/" class="nav__link nav__link--dropdown-link">Tech100 AI Ethics &amp; Governance Index</a>
                                 <button class="nav__dropdown-toggle" type="button" aria-haspopup="true" aria-expanded="false" aria-controls="tech100-submenu" data-nav-dropdown>
                                     <span class="nav__chevron" aria-hidden="true">▾</span>
                                     <span class="sr-only">Toggle Tech100 menu</span>
@@ -147,7 +147,7 @@
         <small>Preview environment — do not share publicly.</small>
     </div>
     {% endif %}
-    <div class="consent-banner" data-consent-banner hidden>
+    <div class="consent-banner" data-consent-banner data-nosnippet aria-hidden="true" hidden>
         <div class="shell consent-banner__inner">
             <p>Explore Tech100 AI Ethics &amp; Governance Index performance, constituents, attribution, and scores. Manage your analytics preferences below.</p>
             <div class="consent-banner__actions">
@@ -175,7 +175,7 @@
         {% csrf_token %}
     </form>
 
-    <div id="download-auth-modal" class="modal modal--download" data-download-modal aria-hidden="true" hidden>
+    <div id="download-auth-modal" class="modal modal--download" data-download-modal data-nosnippet aria-hidden="true" hidden>
         <div class="modal__dialog" role="dialog" aria-modal="true" aria-labelledby="download-modal-title">
             <div class="modal__header">
                 <div>
@@ -225,7 +225,7 @@
         </div>
     </div>
 
-    <div id="consent-modal" class="modal modal--consent" data-consent-modal aria-hidden="true" hidden>
+    <div id="consent-modal" class="modal modal--consent" data-consent-modal data-nosnippet aria-hidden="true" hidden>
         <div class="modal__dialog" role="dialog" aria-modal="true" aria-labelledby="consent-modal-title">
             <div class="modal__header">
                 <div>
@@ -309,7 +309,7 @@
                 <a href="{% url 'press_index' %}" class="footer__link">Press</a>
             </div>
             <div class="footer__column">
-                <h4>Tech100 AI Ethics &amp; Gov Index</h4>
+                <h4>Tech100 AI Ethics &amp; Governance Index</h4>
                 <a href="/tech100/index/" class="footer__link">Tech100 AI Ethics &amp; Governance Index</a>
                 <a href="/tech100/performance/" class="footer__link">Performance</a>
                 <a href="/tech100/portfolio/" class="footer__link">Portfolio analytics</a>
@@ -333,9 +333,9 @@
         </div>
     </footer>
 
-    <a class="chat-fab" href="{% url 'ask2:ask2_page' %}" aria-label="Open Ask2 AI Assistant">
+    <a class="chat-fab" href="{% url 'ask2:ask2_page' %}" aria-label="Open Ask2" data-nosnippet>
         <span class="chat-fab__icon" aria-hidden="true">💬</span>
-        <span class="chat-fab__label">Ask2 AI</span>
+        <span class="chat-fab__label">Ask2</span>
     </a>
 
     {% block extra_scripts %}{% endblock %}

--- a/website_django/templates/home.html
+++ b/website_django/templates/home.html
@@ -1,8 +1,8 @@
 {% extends "base.html" %}
 {% load static %}
 
-{% block title %}SustainaCore | Open ESG & AI governance{% endblock %}
-{% block meta_description %}Open ESG and AI governance data with the Tech100 AI Ethics &amp; Governance Index, curated news, and the Ask2 assistant from SustainaCore.{% endblock %}
+{% block title %}SustainaCore | AI governance data, regulation, and Ask2{% endblock %}
+{% block meta_description %}SustainaCore helps researchers, operators, and governance teams compare AI companies, track Global AI Regulation, ask Ask2, and verify methodology.{% endblock %}
 
 {% block extra_head %}
   <script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.1/dist/chart.umd.min.js" defer></script>
@@ -14,42 +14,42 @@
     <div class="shell sc-container hero__grid">
         <div class="hero__copy">
             <p class="eyebrow">Open AI governance intelligence</p>
-            <h1>Evidence-ready signals for responsible technology.</h1>
-            <p class="lead">SustainaCore combines transparent data, reproducible indicators, and human context so teams can evaluate how technology companies govern AI responsibly.</p>
+            <h1>SustainaCore makes AI governance easier to verify.</h1>
+            <p class="lead">SustainaCore is a public research site for comparing company AI governance, tracking Global AI Regulation, asking grounded questions, and checking the methodology behind the data.</p>
             <div class="actions">
-                <a class="btn btn--primary" href="/tech100/index/">Explore Tech100 AI Ethics &amp; Gov Index</a>
-                <a class="btn btn--ghost" href="{% url 'ask2:ask2_page' %}" aria-label="Talk to our Ask2 AI Assistant">Talk to Ask2</a>
+                <a class="btn btn--primary" href="/tech100/index/">Compare companies</a>
+                <a class="btn btn--ghost" href="{% url 'ask2:ask2_page' %}" aria-label="Ask a question with Ask2">Ask2</a>
             </div>
             <ul class="hero__bullets">
-                <li>Compare companies on transparency, accountability, and oversight.</li>
-                <li>Monitor regulatory signals across jurisdictions.</li>
-                <li>Ask questions in plain language with grounded answers.</li>
+                <li>For analysts, founders, policy teams, and researchers who need source-aware AI governance signals.</li>
+                <li>Data freshness, methodology, corrections, and GitHub links are surfaced where decisions start.</li>
+                <li>Start with company comparison, regulation tracking, Ask2, or methodology verification.</li>
             </ul>
         </div>
         <div class="home-launchpad">
             <div class="launch-card">
                 <span class="launch-card__icon">📈</span>
-                <h3 class="h5">Tech100 AI Ethics &amp; Gov Index</h3>
+                <h3 class="h5">Compare companies</h3>
                 <p class="muted">Performance, constituents, attribution, and governance scores.</p>
                 <a class="text-link" href="/tech100/index/">Index overview →</a>
             </div>
             <div class="launch-card">
-                <span class="launch-card__icon">💬</span>
-                <h3 class="h5">Ask2 AI Chat</h3>
-                <p class="muted">Ask questions in natural language with cited answers.</p>
-                <a class="text-link" href="{% url 'ask2:ask2_page' %}">Open Ask2 →</a>
-            </div>
-            <div class="launch-card">
                 <span class="launch-card__icon">🌐</span>
-                <h3 class="h5">Global AI Regulation</h3>
+                <h3 class="h5">Track AI regulation</h3>
                 <p class="muted">Explore AI policy coverage and jurisdiction detail.</p>
                 <a class="text-link" href="/ai-regulation/">View the globe →</a>
             </div>
             <div class="launch-card">
-                <span class="launch-card__icon">📰</span>
-                <h3 class="h5">News &amp; Insights</h3>
-                <p class="muted">Curated governance headlines and evidence updates.</p>
-                <a class="text-link" href="{% url 'news' %}">Browse news →</a>
+                <span class="launch-card__icon">💬</span>
+                <h3 class="h5">Ask a question</h3>
+                <p class="muted">Ask2 answers plain-language questions with source-aware context.</p>
+                <a class="text-link" href="{% url 'ask2:ask2_page' %}">Open Ask2 →</a>
+            </div>
+            <div class="launch-card">
+                <span class="launch-card__icon">✓</span>
+                <h3 class="h5">Verify methodology</h3>
+                <p class="muted">Review methodology, corrections, GitHub, and transparency notes.</p>
+                <a class="text-link" href="/tech100/methodology/">Check methodology →</a>
             </div>
         </div>
     </div>
@@ -59,17 +59,30 @@
     <div class="shell sc-container">
         <div class="section__header section__header--split">
             <div>
-                <span class="pill pill--soft">Tech100 AI Ethics &amp; Gov Index Snapshot</span>
+                <span class="pill pill--soft">Tech100 AI Ethics &amp; Governance Index Snapshot</span>
                 <h2>Performance at a glance</h2>
-                <p class="muted">A compact view of index performance and risk signals.</p>
+                <p class="muted">Server-rendered summary first, then interactive charts where data is available.</p>
             </div>
         </div>
 
         {% if tech100_snapshot.data_error %}
             <div class="alert alert--warning" data-tech100-home-empty="1">
-                Live Tech100 AI Ethics &amp; Governance Index data is temporarily unavailable; please try again later.
+                Live Tech100 AI Ethics &amp; Governance Index data is temporarily unavailable. The page is hiding stale metrics rather than guessing.
             </div>
         {% elif tech100_snapshot.has_data %}
+        <section class="card card--lined" aria-labelledby="home-tech100-fallback-heading">
+            <h3 class="h5" id="home-tech100-fallback-heading">Latest Tech100 AI Ethics &amp; Governance Index summary</h3>
+            <p class="muted">
+                Latest index data is as of <strong data-date-format="as-of" data-date-value="{{ tech100_snapshot.as_of }}">{{ tech100_snapshot.as_of }}</strong>.
+                The current level is <strong>{{ tech100_snapshot.latest_level_display|default:"not available" }}</strong>,
+                with YTD return <strong>{{ tech100_snapshot.ret_ytd_display|default:"not available" }}</strong>.
+            </p>
+            <p class="muted">
+                Review the <a class="text-link" href="/tech100/methodology/">methodology</a>,
+                browse <a class="text-link" href="/tech100/company/">company reports</a>, or
+                <a class="text-link" href="/corrections/">request a correction</a>.
+            </p>
+        </section>
         <div class="tech100-home__grid"
                  data-tech100-home-has-data="1"
                  data-level-count="{{ tech100_snapshot.levels_count }}"
@@ -78,7 +91,7 @@
                 <div class="card sc-card tech100-home__chart">
                     <div class="tech100-home__chart-header sc-card__header sc-card__header--tight">
                         <div class="sc-card__title">
-                            <h3 class="h4">Tech100 AI Ethics &amp; Gov Index</h3>
+                            <h3 class="h4">Tech100 AI Ethics &amp; Governance Index</h3>
                             <p class="muted tech100-home__as-of">As of <span data-date-format="as-of" data-date-value="{{ tech100_snapshot.as_of }}">{{ tech100_snapshot.as_of }}</span></p>
                         </div>
                         <div class="tech100-index__range tech100-home__range sc-segmented">
@@ -284,10 +297,10 @@
     <div class="shell sc-container">
         <div class="section__header section__header--split">
             <div>
-                <h2>Latest from Tech100 AI Ethics &amp; Gov Index</h2>
+                <h2>Latest from Tech100 AI Ethics &amp; Governance Index</h2>
                 <p class="muted">A snapshot of company scores before you dive into the full index.</p>
             </div>
-            <a class="text-link" href="/tech100/index/">Open Tech100 AI Ethics &amp; Gov Index →</a>
+            <a class="text-link" href="/tech100/index/">Open Tech100 AI Ethics &amp; Governance Index →</a>
         </div>
         {% include "partials/tech100_snapshot_table.html" %}
     </div>
@@ -343,15 +356,15 @@
         <div class="cards cards--three">
             <div class="card">
                 <div class="card__icon">📊</div>
-                <p class="pill pill--soft">Tech100 AI Ethics &amp; Gov Index</p>
+                <p class="pill pill--soft">Tech100 AI Ethics &amp; Governance Index</p>
                 <h3>Governance &amp; ethics index</h3>
                 <p class="muted">Sortable, comparable scores across transparency, accountability, and oversight pillars.</p>
-                <a class="btn btn--secondary" href="/tech100/index/">Open Tech100 AI Ethics &amp; Gov Index</a>
+                <a class="btn btn--secondary" href="/tech100/index/">Open Tech100 AI Ethics &amp; Governance Index</a>
             </div>
             <div class="card">
                 <div class="card__icon">💡</div>
                 <p class="pill pill--soft">Ask2</p>
-                <h3>AI assistant with evidence</h3>
+                <h3>Ask2 with evidence</h3>
                 <p class="muted">Ask questions in natural language and get grounded answers sourced from the SustainaCore backend.</p>
                 <a class="btn btn--secondary" href="{% url 'ask2:ask2_page' %}" aria-label="Chat with the Ask2 AI Assistant">Chat with Ask2</a>
             </div>

--- a/website_django/templates/partials/tech100_nav.html
+++ b/website_django/templates/partials/tech100_nav.html
@@ -48,7 +48,7 @@
       href="/tech100/index/"
       {% if request.path == '/tech100/index/' %}aria-current="page"{% endif %}
     >
-      Tech100 AI Index
+      Tech100 Index
     </a>
     <a
       class="tech100-nav__link sc-tabs__link {% if request.path == '/tech100/performance/' %}is-active{% endif %}"

--- a/website_django/templates/partials/tech100_snapshot_table.html
+++ b/website_django/templates/partials/tech100_snapshot_table.html
@@ -8,7 +8,7 @@
       <div class="table__cell table__cell--right" role="columnheader">Governance Structure</div>
       <div class="table__cell table__cell--right" role="columnheader">Regulatory Alignment</div>
       <div class="table__cell table__cell--right" role="columnheader">Stakeholder Engagement</div>
-      <div class="table__cell table__cell--right" role="columnheader">Composite AI Gov &amp; Ethics</div>
+      <div class="table__cell table__cell--right" role="columnheader">Composite AI Governance &amp; Ethics</div>
     </div>
     {% for company in tech100_preview %}
     <div class="table__row{% if company.ticker %} table__row--clickable{% endif %}"

--- a/website_django/templates/press_index.html
+++ b/website_django/templates/press_index.html
@@ -1,7 +1,7 @@
 {% extends "base.html" %}
 
 {% block title %}Press &amp; Updates | SustainaCore{% endblock %}
-{% block meta_description %}Press resources and updates from SustainaCore, including TECH100 research, company reports, AI regulation coverage, and newsroom contacts.{% endblock %}
+{% block meta_description %}Press resources and updates from SustainaCore, including Tech100 research, company reports, Global AI Regulation coverage, and newsroom contacts.{% endblock %}
 
 {% block content %}
 <section class="section section--with-header">
@@ -25,7 +25,7 @@
                 <a class="btn btn--secondary" href="mailto:info@sustainacore.org">info@sustainacore.org</a>
             </div>
             <div class="card">
-                <p class="pill pill--soft">Tech100 AI Index</p>
+                <p class="pill pill--soft">Tech100 AI Ethics &amp; Governance Index</p>
                 <h3>Index background</h3>
                 <p class="muted">Learn how the Tech100 AI Ethics &amp; Governance Index benchmarks governance and ethics across AI leaders.</p>
                 <a class="btn btn--secondary" href="{% url 'press_tech100' %}">Tech100 press kit</a>

--- a/website_django/templates/tech100.html
+++ b/website_django/templates/tech100.html
@@ -10,7 +10,7 @@
   <div class="shell">
     <div class="section__header">
       <div>
-        <span class="pill pill--soft">Tech100 AI Ethics &amp; Gov Index</span>
+        <span class="pill pill--soft">Tech100 AI Ethics &amp; Governance Index</span>
         <h1>Governance scores</h1>
         <p class="muted">Tech100 AI Ethics &amp; Governance Index ranking and filters.</p>
         <p class="disclaimer-banner">
@@ -32,7 +32,7 @@
     <div class="card">
       <div class="card__header card__header--split">
         <div>
-          <h2 class="h4">Tech100 AI Ethics &amp; Gov Index – Constituents</h2>
+          <h2 class="h4">Tech100 AI Ethics &amp; Governance Index - Constituents</h2>
           <p class="muted" id="constituents-summary">
             {% if is_preview %}
               Showing {{ preview_limit }} of {{ total_count }} companies (preview). Verify your email to unlock the full list.
@@ -298,7 +298,7 @@
           </table>
       </div>
       {% if is_preview %}
-      <div class="constituents-locked" data-constituents-locked data-open-download-modal data-intent="unlock_table"
+      <div class="constituents-locked" data-constituents-locked data-nosnippet data-open-download-modal data-intent="unlock_table"
            data-next-url="{{ request.get_full_path }}"
            data-port-date="{{ filters.port_date }}"
            data-page="/tech100/scores/"
@@ -356,6 +356,7 @@
   <div
     class="modal"
     id="tech100-modal"
+    data-nosnippet
     role="dialog"
     aria-modal="true"
     aria-labelledby="tech100-modal-title"

--- a/website_django/templates/tech100_company.html
+++ b/website_django/templates/tech100_company.html
@@ -87,7 +87,7 @@
             <span data-company-name>{{ company_name }}</span>
             <span class="muted">({{ ticker }})</span>
           </h1>
-          <p class="muted">Dynamic company report with Tech100 AI Ethics &amp; Governance Index benchmarks.</p>
+          <p class="muted">Company report with Tech100 AI Ethics &amp; Governance Index benchmarks, latest score context, and public methodology links.</p>
           {% if summary_line %}
           <p class="tech100-company__summary-text">{{ summary_line }}</p>
           {% endif %}
@@ -103,6 +103,23 @@
           {% endif %}
         </div>
       </div>
+
+      <section class="card card--lined" aria-labelledby="company-crawl-summary-heading">
+        <h2 class="h4" id="company-crawl-summary-heading">{{ company_name }} Tech100 summary</h2>
+        <p class="muted">
+          {% if latest_date %}Latest data is as of <strong data-company-summary-date>{{ latest_date }}</strong>.{% else %}Latest data date is unavailable.{% endif %}
+          {% if latest_rank %} {{ company_name }} ranks <strong>{{ latest_rank }}</strong> in the Tech100 AI Ethics &amp; Governance Index.{% endif %}
+          The current composite AI Governance &amp; Ethics Score is
+          <strong>{{ latest_scores_display.composite|default:"not available" }}</strong>.
+          {% if sector %} Sector context: <strong>{{ sector }}</strong>.{% endif %}
+        </p>
+        <p class="muted">
+          Why this score? The composite score summarizes transparency, ethical principles,
+          governance structure, regulatory alignment, and stakeholder engagement signals.
+          Review the <a class="text-link" href="/tech100/methodology/">methodology</a> or
+          <a class="text-link" href="/corrections/">report a correction</a>.
+        </p>
+      </section>
 
       <div class="card tech100-company__selectors-card">
         <div class="tech100-company__selectors-grid">
@@ -143,7 +160,7 @@
         </div>
         <div class="tech100-company__dashboard-grid">
           <div class="tech100-company__chart-card tech100-company__chart-card--wide" data-chart-metric="composite">
-            <div class="tech100-company__chart-header">Composite AI Gov &amp; Ethics</div>
+            <div class="tech100-company__chart-header">Composite AI Governance &amp; Ethics</div>
             <div class="tech100-company__chart">
               <canvas id="company-chart-composite" role="img" aria-label="Composite score chart"></canvas>
               <p class="tech100-company__chart-error" data-chart-error="composite" hidden></p>
@@ -253,7 +270,7 @@
           </li>
           {% endfor %}
         </ul>
-        <a class="text-link" href="/tech100/company/">Browse all TECH100 companies →</a>
+        <a class="text-link" href="/tech100/company/">Browse all Tech100 companies →</a>
       </div>
       {% endif %}
     </div>

--- a/website_django/templates/tech100_company_root.html
+++ b/website_django/templates/tech100_company_root.html
@@ -35,9 +35,11 @@
       </p>
       <div class="meta-grid">
         {% if latest_date %}
-        <div class="meta-grid__item">Last updated: <strong>{{ latest_date }}</strong></div>
+        <div class="meta-grid__item">Last updated: <strong data-tech100-company-root-date>{{ latest_date }}</strong></div>
         {% endif %}
         <div class="meta-grid__item">Companies: <strong>{{ company_count }}</strong></div>
+        <div class="meta-grid__item"><a class="text-link" href="/tech100/methodology/">Methodology</a></div>
+        <div class="meta-grid__item"><a class="text-link" href="/corrections/">Corrections</a></div>
       </div>
     </header>
 

--- a/website_django/templates/tech100_index_overview.html
+++ b/website_django/templates/tech100_index_overview.html
@@ -14,12 +14,13 @@
     <div class="shell sc-container">
       <div class="section__header sc-page-header">
         <div>
-          <span class="pill pill--soft">Tech100 AI Ethics &amp; Gov Index</span>
+          <span class="pill pill--soft">Tech100 AI Ethics &amp; Governance Index</span>
           <h1>Tech100 AI Ethics &amp; Governance Index</h1>
-          <p class="muted">Performance, constituents, attribution, and governance scores.</p>
+          <p class="muted">A public research index for comparing AI governance performance, constituents, attribution, and company scores.</p>
           <p class="disclaimer-banner">
             <a class="text-link" href="/tech100/methodology/">Methodology &amp; Limitations</a>
             <span class="disclaimer-banner__corrections"> · <a class="text-link" href="/corrections/">Corrections &amp; Complaints</a></span>
+            · <a class="text-link" href="https://github.com/joaotovolli/Sustainacore" target="_blank" rel="noreferrer">GitHub transparency</a>
             · Research only. Not investment advice. Not affiliated with any company, exchange, or index provider.
           </p>
         </div>
@@ -31,7 +32,7 @@
 
       {% if data_error %}
         <div class="alert alert--warning" data-tech100-empty-state="1">
-          Live Tech100 AI Ethics &amp; Governance Index data is temporarily unavailable; please try again later.
+          Live Tech100 AI Ethics &amp; Governance Index data is temporarily unavailable. This page is showing no stale metrics rather than guessing.
         </div>
       {% else %}
         <div id="tech100-data-status"
@@ -61,6 +62,21 @@
             <canvas id="tech100-level-chart" aria-label="Tech100 index level chart" role="img"></canvas>
           </div>
         </div>
+
+        <section class="card card--lined" aria-labelledby="tech100-freshness-heading">
+          <h2 class="h4" id="tech100-freshness-heading">Data freshness and trust</h2>
+          <p class="muted">
+            This overview, the top-constituents table, and the latest score snapshot are rendered from the same
+            latest Tech100 AI Ethics &amp; Governance Index date: <strong data-tech100-freshness-date>{{ latest_date }}</strong>.
+            If an upstream endpoint is unavailable, SustainaCore shows a warning instead of mixing incompatible dates.
+          </p>
+          <p class="muted">
+            Methodology, limitations, and correction routes are public:
+            <a class="text-link" href="/tech100/methodology/">methodology</a>,
+            <a class="text-link" href="/corrections/">corrections</a>, and
+            <a class="text-link" href="https://github.com/joaotovolli/Sustainacore" target="_blank" rel="noreferrer">GitHub</a>.
+          </p>
+        </section>
 
         <div class="tech100-index__kpis">
           <div class="card kpi-card sc-metric-card">

--- a/website_django/templates/tech100_portfolio.html
+++ b/website_django/templates/tech100_portfolio.html
@@ -2,7 +2,7 @@
 {% load static %}
 
 {% block title %}Tech100 Portfolio Analytics | SustainaCore{% endblock %}
-{% block meta_description %}Compare official TECH100 against supported governance, momentum, low-volatility, and hybrid model portfolios with real portfolio analytics from SustainaCore.{% endblock %}
+{% block meta_description %}Compare the official Tech100 AI Ethics & Governance Index against supported governance, momentum, low-volatility, and hybrid model portfolios with real portfolio analytics from SustainaCore.{% endblock %}
 
 {% block extra_head %}
   <script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.1/dist/chart.umd.min.js" defer></script>
@@ -15,8 +15,8 @@
       <div class="section__header sc-page-header tech100-portfolio__header">
         <div class="tech100-portfolio__header-copy">
           <span class="pill pill--soft">Tech100 Portfolio Analytics</span>
-          <h1>TECH100 Portfolio Analytics</h1>
-          <p class="muted">A portfolio research workspace built only on the model families and analytics the merged TECH100 backend contract actually supports.</p>
+          <h1>Tech100 Portfolio Analytics</h1>
+          <p class="muted">A portfolio research workspace built only on the model families and analytics the merged Tech100 backend contract actually supports.</p>
           {% if latest_trade_date %}
             <p class="tech100-portfolio__effective-date" id="portfolio-effective-date">
               As of <span data-date-format="as-of" data-date-value="{{ latest_trade_date }}">{{ latest_trade_date }}</span>
@@ -42,7 +42,7 @@
 
       {% if data_error %}
         <div class="alert alert--warning" data-tech100-empty-state="1">
-          TECH100 portfolio analytics are temporarily unavailable. The page is hiding portfolio sections instead of rendering partial claims.
+          Tech100 portfolio analytics are temporarily unavailable. The page is hiding portfolio sections instead of rendering partial claims.
         </div>
       {% elif data_empty %}
         <div class="card sc-card tech100-portfolio__empty" data-tech100-portfolio-empty="1">
@@ -265,7 +265,7 @@
                 </details>
               </div>
               <div class="tech100-portfolio__chart-stage">
-                <canvas id="tech100-portfolio-level-chart" role="img" aria-label="TECH100 portfolio comparison chart"></canvas>
+                <canvas id="tech100-portfolio-level-chart" role="img" aria-label="Tech100 portfolio comparison chart"></canvas>
               </div>
               <div class="tech100-portfolio__legend" id="tech100-portfolio-legend"></div>
             </div>


### PR DESCRIPTION
## Summary
- Improves first-visit clarity, crawlable fallback content, snippet hygiene, and trust links across the public website.
- Keeps the change scoped to VM2 website code and README content. Production impact: none.

## Changes
- Reworked the home page intro and added a compact Start here journey for comparing companies, tracking Global AI Regulation, asking Ask2, and verifying methodology/GitHub.
- Added visible Tech100 freshness/trust copy and server-rendered fallback summaries for the Tech100 overview and company pages.
- Added server-rendered Global AI Regulation fallback summary/table content when snapshot data is available, with honest unavailable copy when it is not.
- Marked hidden consent, auth, modal, and gated-preview UI with snippet-safe attributes while preserving accessible modal behavior.
- Made methodology, corrections, GitHub, and transparency links more visible from Tech100 surfaces.
- Standardized prominent public naming around SustainaCore, Tech100 AI Ethics & Governance Index, Global AI Regulation, Ask2, and News & Insights.
- Updated the README top section with the live site, product explanation, public modules, architecture summary, verification note, and exploration links.
- Added lightweight deterministic tests for snippet hygiene, page metadata, fallback content, and Tech100 freshness consistency.

## Testing
- `git diff --check` - passed.
- `DJANGO_SECRET_KEY=test /tmp/sustainacore-website-venv/bin/python website_django/manage.py check` - passed.
- `DJANGO_SECRET_KEY=test /tmp/sustainacore-website-venv/bin/python website_django/manage.py test core.tests.test_seo --noinput -v 1` - passed, 11 tests.
- `DJANGO_SECRET_KEY=test /tmp/sustainacore-website-venv/bin/python website_django/manage.py test core.tests.test_tech100_index_views core.tests.test_tech100_views core.tests.test_tech100_portfolio_views ai_reg.tests.test_views core.tests.test_home_view --noinput -v 1` - passed, 39 tests.
- GitHub checks passed for this PR.

## Evidence
- Preview: https://preview.sustainacore.org/
- Production reference: https://sustainacore.org/
- UI compare run: https://github.com/joaotovolli/Sustainacore/actions/runs/26419155484
- UI compare job: https://github.com/joaotovolli/Sustainacore/actions/runs/26419155484/job/77770003677
- Artifact download: `gh run download 26419155484 -n ui-home-compare`
- Local server command: `DJANGO_SECRET_KEY=test TECH100_UI_DATA_MODE=fixture /tmp/sustainacore-website-venv/bin/python website_django/manage.py runserver 127.0.0.1:8127 --noreload`
- Local smoke results:
  - `/` - HTTP 200, expected SustainaCore/Start here marker present.
  - `/tech100/index/` - HTTP 200, expected Data freshness and trust marker present.
  - `/tech100/company/` - HTTP 200, expected Tech100 company marker present.
  - `/tech100/company/TCH01/` - HTTP 200, expected Tech100 summary/Why this score marker present.
  - `/ai-regulation/` - HTTP 200, expected Global AI Regulation fallback marker present.
  - `/news/` - HTTP 200, expected News marker present.
  - `/tech100/methodology/` - HTTP 200, expected methodology marker present.
  - `/robots.txt` - HTTP 200, expected robots marker present.
  - `/sitemap.xml` - HTTP 200, expected sitemap marker present.

## Notes / Follow-ups
- Known local limitation: the WSL2 checkout does not have the Oracle client or VM1 backend available, so some tests log expected fallback warnings while still passing.
- Rollback: close this PR without merging, delete branch `improve/website-visibility-trust`, or revert the merge commit if it is merged later.
- Production was not changed.
- Please review and approve before any merge or deploy.
