### PR TITLE
Fix SC_IDX stale provider readiness catch-up

### DIFF
--- a/app/index_engine/orchestration.py
+++ b/app/index_engine/orchestration.py
@@ -452,30 +452,70 @@ def _eligible_probe_window(
     return eligible[-lookback_days:]
 
 
-def _provider_readiness_status(provider: Any, probe_symbol: str, day: _dt.date) -> Literal["OK", "NO_DATA"]:
+READINESS_PROBE_SYMBOLS_ENV = "SC_IDX_READINESS_PROBE_SYMBOLS"
+
+
+def _provider_no_data_error(exc: Exception) -> bool:
+    text = str(exc).lower()
+    return "no data" in text or "not ready" in text or "404" in text or "market_data_http_error:400" in text
+
+
+def _readiness_probe_symbols(default_symbol: str) -> list[str]:
+    raw_symbols = os.getenv(READINESS_PROBE_SYMBOLS_ENV) or default_symbol
+    symbols = [symbol.strip().upper() for symbol in raw_symbols.split(",") if symbol.strip()]
+    tickers = [symbol.strip().upper() for symbol in (os.getenv("SC_IDX_TICKERS") or "").split(",") if symbol.strip()]
+    ordered: list[str] = []
+    for symbol in symbols + tickers[:3]:
+        if symbol and symbol not in ordered:
+            ordered.append(symbol)
+    return ordered or [default_symbol]
+
+
+def _provider_symbol_readiness_status(provider: Any, probe_symbol: str, day: _dt.date) -> Literal["OK", "NO_DATA"]:
+    fetch_single_day_bar = getattr(provider, "fetch_single_day_bar", None)
+    if callable(fetch_single_day_bar):
+        try:
+            rows = fetch_single_day_bar(probe_symbol, day)
+        except Exception as exc:
+            if _provider_no_data_error(exc):
+                rows = []
+            else:
+                raise
+        if rows:
+            return "OK"
+
     has_eod_for_date = getattr(provider, "has_eod_for_date", None)
     if callable(has_eod_for_date):
         try:
             return "OK" if has_eod_for_date(probe_symbol, day) else "NO_DATA"
         except Exception as exc:
-            text = str(exc).lower()
-            if (
-                "no data" in text
-                or "not ready" in text
-                or "404" in text
-                or "market_data_http_error:400" in text
-            ):
+            if _provider_no_data_error(exc):
                 return "NO_DATA"
             raise
 
-    try:
-        rows = provider.fetch_single_day_bar(probe_symbol, day)
-    except Exception as exc:
-        text = str(exc).lower()
-        if "no data" in text or "not ready" in text or "404" in text or "market_data_http_error:400" in text:
-            return "NO_DATA"
-        raise
-    return "OK" if rows else "NO_DATA"
+    return "NO_DATA"
+
+
+def _provider_readiness_status(
+    provider: Any,
+    probe_symbols: str | list[str],
+    day: _dt.date,
+) -> Literal["OK", "NO_DATA"]:
+    symbols = [probe_symbols] if isinstance(probe_symbols, str) else list(probe_symbols)
+    errors: list[Exception] = []
+    for symbol in symbols:
+        try:
+            status = _provider_symbol_readiness_status(provider, symbol, day)
+        except Exception as exc:
+            errors.append(exc)
+            continue
+        if status == "OK":
+            return "OK"
+    if errors and not symbols:
+        raise errors[-1]
+    if errors and len(errors) == len(symbols):
+        raise errors[-1]
+    return "NO_DATA"
 
 
 def _report_root_cause(state: PipelineGraphState) -> str | None:
@@ -816,6 +856,7 @@ class SCIdxPipelineRuntime:
         tried_ready_dates: list[_dt.date] = []
         if candidate_end is not None and next_missing_canon is not None and next_missing_canon <= candidate_end:
             probe_symbol_for_ready = os.getenv(run_daily.PROBE_SYMBOL_ENV, "SPY")
+            probe_symbols_for_ready = _readiness_probe_symbols(probe_symbol_for_ready)
             lookback_days = max(
                 1,
                 _env_int(
@@ -830,7 +871,7 @@ class SCIdxPipelineRuntime:
             )
 
             def _probe(day: _dt.date) -> str:
-                return _provider_readiness_status(provider, probe_symbol_for_ready, day)
+                return _provider_readiness_status(provider, probe_symbols_for_ready, day)
 
             try:
                 ready_end, tried_ready_dates = run_daily._probe_with_fallback(
@@ -995,6 +1036,7 @@ class SCIdxPipelineRuntime:
         run_daily = self._load_run_daily_module()
         provider = run_daily._load_provider_module()
         probe_symbol = os.getenv(run_daily.PROBE_SYMBOL_ENV, "SPY")
+        probe_symbols = _readiness_probe_symbols(probe_symbol)
         candidate_end = _coerce_date(context.get("candidate_end_date"))
         trading_days = _context_trading_days(context, default_end=candidate_end)
         if candidate_end is None or not trading_days:
@@ -1006,7 +1048,7 @@ class SCIdxPipelineRuntime:
             }
 
         def _probe(day: _dt.date) -> str:
-            return _provider_readiness_status(provider, probe_symbol, day)
+            return _provider_readiness_status(provider, probe_symbols, day)
 
         try:
             ready_end, tried = run_daily._probe_with_fallback(candidate_end, trading_days, probe_fn=_probe)

--- a/app/index_engine/orchestration.py
+++ b/app/index_engine/orchestration.py
@@ -967,7 +967,14 @@ class SCIdxPipelineRuntime:
             and next_missing_canon <= effective_end
         )
 
-        status = "DEGRADED" if warnings else "OK"
+        terminal_warnings = list(warnings)
+        if (
+            not ingest_required
+            and next_missing_calc is None
+            and next_missing_portfolio is None
+        ):
+            terminal_warnings = []
+        status = "DEGRADED" if terminal_warnings else "OK"
         detail = (
             f"candidate_end={candidate_end.isoformat() if candidate_end else None} "
             f"ready_end={effective_end.isoformat() if effective_end else None} "
@@ -1014,12 +1021,13 @@ class SCIdxPipelineRuntime:
         return {
             "status": status,
             "detail": detail,
-            "warnings": warnings,
+            "warnings": terminal_warnings,
             "counts": {
                 "candidate_end_date": candidate_end,
                 "ready_end_date": effective_end,
                 "max_provider_calls": max_provider_calls,
                 "remaining_daily": remaining_daily,
+                "calendar_warnings": warnings,
             },
             "context": context,
         }

--- a/app/index_engine/orchestration.py
+++ b/app/index_engine/orchestration.py
@@ -1358,6 +1358,36 @@ class SCIdxPipelineRuntime:
                         int(context.get("provider_calls_remaining") or 0) - replacement_calls,
                     )
 
+        trading_days = _context_trading_days(context, default_end=end_day)
+        window_days = [day for day in trading_days if target_day <= day <= end_day]
+        if not window_days and target_day == end_day:
+            window_days = [target_day]
+        missing_real_by_day = {
+            day: engine_db.fetch_missing_real_for_trade_date(day)
+            for day in window_days
+        }
+        missing_real_count = sum(len(tickers) for tickers in missing_real_by_day.values())
+        if missing_real_count == 0 and not replacement_tickers:
+            summary = {
+                "total_imputed": 0,
+                "canon_imputed": 0,
+                "missing_without_prior": 0,
+                "missing_without_prior_rows": [],
+                "per_date": [],
+                "top_tickers": [],
+            }
+            return {
+                "status": "SKIP",
+                "detail": f"no_imputation_required:{target_day.isoformat()}..{end_day.isoformat()}",
+                "counts": {
+                    **summary,
+                    "missing_real_count": 0,
+                    "replacement_calls_used": replacement_calls,
+                    "replacement_tickers": replacement_tickers,
+                },
+                "context": {"imputation_summary": summary},
+            }
+
         max_runtime_sec = _env_float("SC_IDX_IMPUTE_TIMEOUT_SEC", 300.0)
         try:
             summary = impute_module.impute_missing_prices(

--- a/app/index_engine/run_report.py
+++ b/app/index_engine/run_report.py
@@ -213,7 +213,11 @@ def _freshness_health(
         if signal not in deduped_signals:
             deduped_signals.append(signal)
 
-    if root_cause == "determine_target_dates" or status_reason == "determine_target_dates":
+    target_date_failed = (
+        terminal_status in {"failed", "blocked"}
+        and (root_cause == "determine_target_dates" or status_reason == "determine_target_dates")
+    )
+    if target_date_failed:
         verdict = "failed"
         reason = "target_date_determination_failed"
     elif status_reason == "provider_not_ready":

--- a/tests/test_calc_index_window.py
+++ b/tests/test_calc_index_window.py
@@ -66,3 +66,27 @@ def test_select_calc_window_reprocesses_when_stats_lag_levels():
     assert status is None
     assert new_start == dt.date(2026, 4, 1)
     assert filtered == [dt.date(2026, 4, 1)]
+
+
+def test_extend_short_trading_calendar_adds_recent_missing_target():
+    trading_days = [dt.date(2026, 5, 28)]
+
+    extended, synthetic = calc_index._extend_short_trading_calendar(
+        trading_days,
+        start_date=dt.date(2026, 5, 28),
+        end_date=dt.date(2026, 5, 29),
+    )
+
+    assert synthetic == [dt.date(2026, 5, 29)]
+    assert extended == [dt.date(2026, 5, 28), dt.date(2026, 5, 29)]
+
+
+def test_extend_short_trading_calendar_handles_single_missing_target():
+    extended, synthetic = calc_index._extend_short_trading_calendar(
+        [],
+        start_date=dt.date(2026, 5, 29),
+        end_date=dt.date(2026, 5, 29),
+    )
+
+    assert synthetic == [dt.date(2026, 5, 29)]
+    assert extended == [dt.date(2026, 5, 29)]

--- a/tests/test_index_engine_ingest.py
+++ b/tests/test_index_engine_ingest.py
@@ -4,6 +4,7 @@ import sys
 
 sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[1]))
 
+from tools.index_engine import ingest_prices
 from tools.index_engine.ingest_prices import compute_canonical_rows, _build_raw_rows_from_provider
 
 
@@ -39,3 +40,62 @@ def test_build_raw_rows_skips_null_close():
     raw_rows = _build_raw_rows_from_provider(rows)
     assert len(raw_rows) == 1
     assert raw_rows[0]["ticker"] == "BBB"
+
+
+def test_backfill_extends_short_cached_calendar_to_ready_end(monkeypatch):
+    calls = []
+    raw_written = []
+    canon_written = []
+
+    monkeypatch.setattr(
+        ingest_prices,
+        "fetch_trading_days",
+        lambda start, end: [_dt.date(2026, 5, 28)],
+    )
+    monkeypatch.setattr(ingest_prices, "fetch_impacted_tickers_for_trade_date", lambda day: ["AAPL"])
+    monkeypatch.setattr(ingest_prices, "fetch_max_ok_trade_date", lambda ticker, provider: None)
+
+    def fake_fetch_provider_rows(ticker, start_date, end_date):
+        calls.append((ticker, start_date, end_date))
+        return [
+            {"ticker": ticker, "trade_date": "2026-05-28", "close": 101.0, "adj_close": 101.0},
+            {"ticker": ticker, "trade_date": "2026-05-29", "close": 102.0, "adj_close": 102.0},
+        ]
+
+    def fake_upsert_raw(rows):
+        raw_written.extend(rows)
+        return len(rows)
+
+    def fake_upsert_canon(rows):
+        canon_written.extend(rows)
+        return len(rows)
+
+    monkeypatch.setattr(ingest_prices, "_fetch_provider_rows", fake_fetch_provider_rows)
+    monkeypatch.setattr(ingest_prices, "upsert_prices_raw", fake_upsert_raw)
+    monkeypatch.setattr(ingest_prices, "upsert_prices_canon", fake_upsert_canon)
+
+    args = type(
+        "Args",
+        (),
+        {
+            "start": "2026-05-28",
+            "end": "2026-05-29",
+            "tickers": None,
+            "debug": False,
+            "max_provider_calls": None,
+        },
+    )()
+
+    code, summary = ingest_prices._run_backfill(args)
+
+    assert code == 0
+    assert calls == [("AAPL", _dt.date(2026, 5, 28), _dt.date(2026, 5, 29))]
+    assert {row["trade_date"] for row in raw_written} == {
+        _dt.date(2026, 5, 28),
+        _dt.date(2026, 5, 29),
+    }
+    assert {row["trade_date"] for row in canon_written} == {
+        _dt.date(2026, 5, 28),
+        _dt.date(2026, 5, 29),
+    }
+    assert summary["max_ok_trade_date"] == _dt.date(2026, 5, 29)

--- a/tests/test_index_engine_ingest.py
+++ b/tests/test_index_engine_ingest.py
@@ -99,3 +99,41 @@ def test_backfill_extends_short_cached_calendar_to_ready_end(monkeypatch):
         _dt.date(2026, 5, 29),
     }
     assert summary["max_ok_trade_date"] == _dt.date(2026, 5, 29)
+
+
+def test_backfill_uses_bounded_weekday_when_cached_calendar_missing_target(monkeypatch):
+    calls = []
+    raw_written = []
+    canon_written = []
+
+    monkeypatch.setattr(ingest_prices, "fetch_trading_days", lambda start, end: [])
+    monkeypatch.setattr(ingest_prices, "fetch_impacted_tickers_for_trade_date", lambda day: ["MSFT"])
+    monkeypatch.setattr(ingest_prices, "fetch_max_ok_trade_date", lambda ticker, provider: None)
+
+    def fake_fetch_provider_rows(ticker, start_date, end_date):
+        calls.append((ticker, start_date, end_date))
+        return [{"ticker": ticker, "trade_date": "2026-05-29", "close": 203.0, "adj_close": 203.0}]
+
+    monkeypatch.setattr(ingest_prices, "_fetch_provider_rows", fake_fetch_provider_rows)
+    monkeypatch.setattr(ingest_prices, "upsert_prices_raw", lambda rows: raw_written.extend(rows) or len(rows))
+    monkeypatch.setattr(ingest_prices, "upsert_prices_canon", lambda rows: canon_written.extend(rows) or len(rows))
+
+    args = type(
+        "Args",
+        (),
+        {
+            "start": "2026-05-29",
+            "end": "2026-05-29",
+            "tickers": None,
+            "debug": False,
+            "max_provider_calls": None,
+        },
+    )()
+
+    code, summary = ingest_prices._run_backfill(args)
+
+    assert code == 0
+    assert calls == [("MSFT", _dt.date(2026, 5, 29), _dt.date(2026, 5, 29))]
+    assert [row["trade_date"] for row in raw_written] == [_dt.date(2026, 5, 29)]
+    assert [row["trade_date"] for row in canon_written] == [_dt.date(2026, 5, 29)]
+    assert summary["max_ok_trade_date"] == _dt.date(2026, 5, 29)

--- a/tests/test_run_pipeline.py
+++ b/tests/test_run_pipeline.py
@@ -864,6 +864,47 @@ def test_portfolio_analytics_reruns_when_positions_lag(monkeypatch, tmp_path):
     assert result["context"]["portfolio_position_max_after"] == dt.date(2026, 4, 1)
 
 
+def test_imputation_skips_when_real_prices_are_complete(monkeypatch, tmp_path):
+    runtime = SCIdxPipelineRuntime(
+        report_dir=tmp_path,
+        telemetry_dir=tmp_path / "telemetry",
+        state_store=_FakeStore(),
+    )
+
+    def _unexpected_impute(**_kwargs):
+        raise AssertionError("imputer should not run when real prices are complete")
+
+    monkeypatch.setenv("SC_IDX_IMPUTED_REPLACEMENT_LIMIT", "0")
+    monkeypatch.setattr(
+        runtime,
+        "_load_impute_module",
+        lambda: SimpleNamespace(
+            select_replacement_tickers=lambda *_args, **_kwargs: [],
+            impute_missing_prices=_unexpected_impute,
+        ),
+    )
+    monkeypatch.setattr(
+        "index_engine.orchestration.engine_db.fetch_missing_real_for_trade_date",
+        lambda trade_date: [],
+    )
+
+    state = _state(
+        smoke=False,
+        context={
+            "calc_target_day": dt.date(2026, 5, 29),
+            "calc_end_date": dt.date(2026, 5, 29),
+            "trading_days": ["2026-05-29"],
+            "provider_calls_remaining": 0,
+        },
+    )
+
+    result = runtime.imputation_or_replacement(state)
+
+    assert result["status"] == "SKIP"
+    assert result["detail"] == "no_imputation_required:2026-05-29..2026-05-29"
+    assert result["counts"]["missing_real_count"] == 0
+
+
 def test_portfolio_analytics_accepts_rebalance_scoped_optimizer_inputs(monkeypatch, tmp_path):
     captured = {}
     current = {

--- a/tests/test_run_pipeline.py
+++ b/tests/test_run_pipeline.py
@@ -702,6 +702,78 @@ def test_determine_target_dates_uses_cached_calendar_when_refresh_raises(monkeyp
     assert any("trading_days_cached:market_data_http_error:400" == warning for warning in result["warnings"])
 
 
+def test_determine_target_dates_suppresses_calendar_warning_when_up_to_date(monkeypatch, tmp_path):
+    trading_days = [dt.date(2026, 5, 28), dt.date(2026, 5, 29)]
+    provider = SimpleNamespace(
+        fetch_api_usage=lambda: {"current_usage": 1, "plan_limit": 8},
+    )
+
+    def _raise_refresh(**_kwargs):
+        raise RuntimeError("market_data_http_error:400")
+
+    trading_days_module = SimpleNamespace(update_trading_days_with_retry=_raise_refresh)
+    fake_run_daily = SimpleNamespace(
+        PROBE_SYMBOL_ENV="SC_IDX_PROBE_SYMBOL",
+        DAILY_LIMIT_ENV="SC_IDX_MARKET_DATA_DAILY_LIMIT",
+        DAILY_BUFFER_ENV="SC_IDX_MARKET_DATA_DAILY_BUFFER",
+        BUFFER_ENV="SC_IDX_MARKET_DATA_CREDIT_BUFFER",
+        DEFAULT_DAILY_LIMIT=800,
+        DEFAULT_BUFFER=25,
+        TRADING_DAYS_RETRY_ENV="SC_IDX_TRADING_DAYS_RETRY_ATTEMPTS",
+        TRADING_DAYS_RETRY_BASE_ENV="SC_IDX_TRADING_DAYS_RETRY_BASE_SEC",
+        PROVIDER_READY_LOOKBACK_DAYS_ENV="SC_IDX_PROVIDER_READY_LOOKBACK_DAYS",
+        DEFAULT_PROVIDER_READY_LOOKBACK_DAYS=5,
+        _load_provider_module=lambda: provider,
+        _load_trading_days_module=lambda: trading_days_module,
+        _compute_daily_budget=lambda daily_limit, daily_buffer, calls_used_today: (800, 775),
+        _resolve_end_date=lambda provider, probe_symbol, today_utc: (
+            dt.date(2026, 5, 29),
+            trading_days,
+            dt.date(2026, 5, 29),
+        ),
+        derive_expected_target_date=lambda provider_latest, today_utc, trading_days, allow_weekday_fallback: (
+            dt.date(2026, 5, 29),
+            "calendar",
+            trading_days,
+            [],
+        ),
+        select_next_missing_trading_day=lambda trading_days, max_canon_trade_date=None: None,
+        _probe_with_fallback=run_daily._probe_with_fallback,
+        compute_eligible_end_date=lambda provider_latest, today_utc, trading_days: dt.date(2026, 5, 29),
+    )
+    runtime = SCIdxPipelineRuntime(report_dir=tmp_path, telemetry_dir=tmp_path / "telemetry", state_store=_FakeStore())
+
+    monkeypatch.setattr(runtime, "_load_run_daily_module", lambda: fake_run_daily)
+    monkeypatch.setattr("index_engine.orchestration.fetch_calls_used_today", lambda *_args, **_kwargs: 0)
+    monkeypatch.setattr("index_engine.orchestration.engine_db.fetch_max_canon_trade_date", lambda: dt.date(2026, 5, 29))
+    monkeypatch.setattr("index_engine.orchestration.db_index_calc.fetch_max_level_date", lambda: dt.date(2026, 5, 29))
+    monkeypatch.setattr("index_engine.orchestration.db_index_calc.fetch_max_contribution_date", lambda: dt.date(2026, 5, 29))
+    monkeypatch.setattr("index_engine.orchestration.db_index_calc.fetch_max_stats_date", lambda: dt.date(2026, 5, 29))
+    monkeypatch.setattr("index_engine.orchestration.db_index_calc.fetch_calc_completion_max_date", lambda: dt.date(2026, 5, 29))
+    monkeypatch.setattr(
+        "index_engine.orchestration.db_portfolio_analytics.fetch_portfolio_analytics_max_date",
+        lambda: dt.date(2026, 5, 29),
+    )
+    monkeypatch.setattr(
+        "index_engine.orchestration.db_portfolio_analytics.fetch_portfolio_position_max_date",
+        lambda: dt.date(2026, 5, 29),
+    )
+    monkeypatch.setattr(
+        "index_engine.orchestration.db_portfolio_analytics.fetch_portfolio_opt_inputs_max_date",
+        lambda: dt.date(2026, 5, 28),
+    )
+    monkeypatch.setattr(
+        "index_engine.orchestration.db_portfolio_analytics.fetch_portfolio_completion_max_date",
+        lambda: dt.date(2026, 5, 29),
+    )
+
+    result = runtime.determine_target_dates(_state(smoke=False))
+
+    assert result["status"] == "OK"
+    assert result["warnings"] == []
+    assert result["counts"]["calendar_warnings"] == ["trading_days_cached:market_data_http_error:400"]
+
+
 def test_target_date_failure_report_requires_operator_action(tmp_path):
     class BrokenTargetRuntime(SmokePipelineRuntime):
         def __init__(self):

--- a/tests/test_run_pipeline.py
+++ b/tests/test_run_pipeline.py
@@ -475,7 +475,7 @@ def test_determine_target_dates_clean_skips_when_provider_not_ready(monkeypatch,
     assert result["context"]["ingest_required"] is False
 
 
-def test_determine_target_dates_maps_readiness_http_400_to_clean_skip(monkeypatch, tmp_path):
+def test_determine_target_dates_uses_window_probe_when_exact_readiness_http_400(monkeypatch, tmp_path):
     trading_days = [dt.date(2026, 5, 26), dt.date(2026, 5, 27), dt.date(2026, 5, 28)]
 
     def _raise_no_bar(_symbol, _day):
@@ -484,7 +484,7 @@ def test_determine_target_dates_maps_readiness_http_400_to_clean_skip(monkeypatc
     provider = SimpleNamespace(
         fetch_api_usage=lambda: {"current_usage": 1, "plan_limit": 8},
         has_eod_for_date=_raise_no_bar,
-        fetch_single_day_bar=lambda *_args, **_kwargs: (_ for _ in ()).throw(AssertionError("fallback not expected")),
+        fetch_single_day_bar=lambda _symbol, day: [{"trade_date": day.isoformat(), "close": "1"}],
     )
     trading_days_module = SimpleNamespace(update_trading_days_with_retry=lambda **kwargs: (True, None))
     fake_run_daily = SimpleNamespace(
@@ -544,11 +544,88 @@ def test_determine_target_dates_maps_readiness_http_400_to_clean_skip(monkeypatc
 
     result = runtime.determine_target_dates(_state(smoke=False))
 
-    assert result["status"] == "SKIP"
-    assert result["terminal_status"] == "clean_skip"
-    assert result["error_token"] == "provider_not_ready"
-    assert result["context"]["provider_ready"] is False
-    assert result["context"]["provider_ready_tried_dates"] == trading_days[::-1]
+    assert result["status"] == "OK"
+    assert result["context"]["provider_ready"] is True
+    assert result["context"]["ready_end_date"] == dt.date(2026, 5, 28)
+    assert result["context"]["ingest_required"] is True
+
+
+def test_determine_target_dates_uses_alternate_probe_symbol_when_primary_missing(monkeypatch, tmp_path):
+    trading_days = [dt.date(2026, 5, 28), dt.date(2026, 5, 29)]
+
+    def _fetch(symbol, day):
+        if symbol == "AAPL" and day == dt.date(2026, 5, 29):
+            return [{"trade_date": day.isoformat(), "close": "1"}]
+        return []
+
+    provider = SimpleNamespace(
+        fetch_api_usage=lambda: {"current_usage": 1, "plan_limit": 8},
+        fetch_single_day_bar=_fetch,
+        has_eod_for_date=lambda _symbol, _day: False,
+    )
+    trading_days_module = SimpleNamespace(update_trading_days_with_retry=lambda **kwargs: (True, None))
+    fake_run_daily = SimpleNamespace(
+        PROBE_SYMBOL_ENV="SC_IDX_PROBE_SYMBOL",
+        DAILY_LIMIT_ENV="SC_IDX_MARKET_DATA_DAILY_LIMIT",
+        DAILY_BUFFER_ENV="SC_IDX_MARKET_DATA_DAILY_BUFFER",
+        BUFFER_ENV="SC_IDX_MARKET_DATA_CREDIT_BUFFER",
+        DEFAULT_DAILY_LIMIT=800,
+        DEFAULT_BUFFER=25,
+        TRADING_DAYS_RETRY_ENV="SC_IDX_TRADING_DAYS_RETRY_ATTEMPTS",
+        TRADING_DAYS_RETRY_BASE_ENV="SC_IDX_TRADING_DAYS_RETRY_BASE_SEC",
+        PROVIDER_READY_LOOKBACK_DAYS_ENV="SC_IDX_PROVIDER_READY_LOOKBACK_DAYS",
+        DEFAULT_PROVIDER_READY_LOOKBACK_DAYS=5,
+        _load_provider_module=lambda: provider,
+        _load_trading_days_module=lambda: trading_days_module,
+        _compute_daily_budget=lambda daily_limit, daily_buffer, calls_used_today: (800, 775),
+        _resolve_end_date=lambda provider, probe_symbol, today_utc: (
+            dt.date(2026, 5, 29),
+            trading_days,
+            dt.date(2026, 5, 29),
+        ),
+        derive_expected_target_date=lambda provider_latest, today_utc, trading_days, allow_weekday_fallback: (
+            dt.date(2026, 5, 29),
+            "calendar",
+            trading_days,
+            [],
+        ),
+        select_next_missing_trading_day=lambda trading_days, max_canon_trade_date=None: dt.date(2026, 5, 28),
+        _probe_with_fallback=run_daily._probe_with_fallback,
+        compute_eligible_end_date=lambda provider_latest, today_utc, trading_days: dt.date(2026, 5, 29),
+    )
+    runtime = SCIdxPipelineRuntime(report_dir=tmp_path, telemetry_dir=tmp_path / "telemetry", state_store=_FakeStore())
+
+    monkeypatch.setenv("SC_IDX_READINESS_PROBE_SYMBOLS", "SPY,AAPL")
+    monkeypatch.setattr(runtime, "_load_run_daily_module", lambda: fake_run_daily)
+    monkeypatch.setattr("index_engine.orchestration.fetch_calls_used_today", lambda *_args, **_kwargs: 0)
+    monkeypatch.setattr("index_engine.orchestration.engine_db.fetch_max_canon_trade_date", lambda: dt.date(2026, 5, 27))
+    monkeypatch.setattr("index_engine.orchestration.db_index_calc.fetch_max_level_date", lambda: dt.date(2026, 5, 27))
+    monkeypatch.setattr("index_engine.orchestration.db_index_calc.fetch_max_contribution_date", lambda: dt.date(2026, 5, 27))
+    monkeypatch.setattr("index_engine.orchestration.db_index_calc.fetch_max_stats_date", lambda: dt.date(2026, 5, 27))
+    monkeypatch.setattr("index_engine.orchestration.db_index_calc.fetch_calc_completion_max_date", lambda: dt.date(2026, 5, 27))
+    monkeypatch.setattr(
+        "index_engine.orchestration.db_portfolio_analytics.fetch_portfolio_analytics_max_date",
+        lambda: dt.date(2026, 5, 27),
+    )
+    monkeypatch.setattr(
+        "index_engine.orchestration.db_portfolio_analytics.fetch_portfolio_position_max_date",
+        lambda: dt.date(2026, 5, 27),
+    )
+    monkeypatch.setattr(
+        "index_engine.orchestration.db_portfolio_analytics.fetch_portfolio_opt_inputs_max_date",
+        lambda: dt.date(2026, 5, 27),
+    )
+    monkeypatch.setattr(
+        "index_engine.orchestration.db_portfolio_analytics.fetch_portfolio_completion_max_date",
+        lambda: dt.date(2026, 5, 27),
+    )
+
+    result = runtime.determine_target_dates(_state(smoke=False))
+
+    assert result["status"] == "OK"
+    assert result["context"]["ready_end_date"] == dt.date(2026, 5, 29)
+    assert result["context"]["ingest_start_date"] == dt.date(2026, 5, 28)
+    assert result["context"]["ingest_required"] is True
 
 
 def test_determine_target_dates_uses_cached_calendar_when_refresh_raises(monkeypatch, tmp_path):

--- a/tests/test_run_report.py
+++ b/tests/test_run_report.py
@@ -75,3 +75,37 @@ def test_build_pipeline_run_summary_does_not_set_failed_stage_for_clean_skip():
     assert summary["overall_health"] == "Skipped"
     assert summary["failed_stage"] is None
     assert summary["freshness"]["health"]["verdict"] == "provider_not_ready"
+
+
+def test_degraded_target_date_warning_keeps_aligned_data_fresh():
+    summary = build_pipeline_run_summary(
+        run_id="run-degraded-fresh",
+        terminal_status="success_with_degradation",
+        started_at="2026-05-31T13:14:59+00:00",
+        stage_results={
+            "determine_target_dates": {"status": "DEGRADED", "counts": {}, "attempts": 1},
+            "calc_index": {"status": "OK", "counts": {}, "attempts": 1},
+            "portfolio_analytics": {"status": "OK", "counts": {}, "attempts": 1},
+            "generate_run_report": {"status": "OK", "counts": {}, "attempts": 1},
+        },
+        context={
+            "ended_at": "2026-05-31T13:15:22+00:00",
+            "expected_target_date": "2026-05-29",
+            "expected_target_source": "weekday_fallback",
+            "max_canon_after_ingest": "2026-05-29",
+            "levels_max_after": "2026-05-29",
+            "stats_max_after": "2026-05-29",
+            "portfolio_max_after": "2026-05-29",
+            "portfolio_position_max_after": "2026-05-29",
+            "repo_root": "/repo",
+            "repo_head": "abc1234",
+        },
+        warnings=["trading_days_weekday_fallback:start=2026-05-29 end=2026-05-29 count=1"],
+        status_reason="determine_target_dates",
+        root_cause=None,
+        remediation=None,
+    )
+
+    assert summary["terminal_status"] == "success_with_degradation"
+    assert summary["freshness"]["health"]["verdict"] == "fresh"
+    assert summary["freshness"]["health"]["reason"] == "aligned_with_expected"

--- a/tools/index_engine/calc_index.py
+++ b/tools/index_engine/calc_index.py
@@ -14,6 +14,7 @@ for path in (REPO_ROOT, APP_ROOT):
         sys.path.insert(0, str(path))
 
 from tools.index_engine.env_loader import load_default_env
+from index_engine.data_quality import generate_weekdays
 from index_engine.alert_state import should_send_alert_once_per_day
 from index_engine.alerts import send_email
 from index_engine.index_calc_v1 import (
@@ -31,6 +32,8 @@ from index_engine import db as engine_db
 BASE_DATE = _dt.date(2025, 1, 2)
 BASE_LEVEL = 1000.0
 UNIVERSE_DEF = "top25_port_weight_gt0_latest_port_date_le_trade_date"
+TRADING_DAY_FALLBACK_MAX_GAP_ENV = "SC_IDX_TRADING_DAY_FALLBACK_MAX_GAP"
+DEFAULT_TRADING_DAY_FALLBACK_MAX_GAP = 3
 
 
 def _parse_date(value: str) -> _dt.date:
@@ -38,6 +41,41 @@ def _parse_date(value: str) -> _dt.date:
     if text == "today":
         return _dt.date.today()
     return _dt.date.fromisoformat(text)
+
+
+def _env_int(name: str, default: int) -> int:
+    raw = os.getenv(name)
+    if raw is None:
+        return default
+    try:
+        return int(raw)
+    except ValueError:
+        return default
+
+
+def _extend_short_trading_calendar(
+    trading_days: List[_dt.date],
+    *,
+    start_date: _dt.date,
+    end_date: _dt.date,
+) -> tuple[List[_dt.date], List[_dt.date]]:
+    if not trading_days:
+        max_gap = max(0, _env_int(TRADING_DAY_FALLBACK_MAX_GAP_ENV, DEFAULT_TRADING_DAY_FALLBACK_MAX_GAP))
+        synthetic_days = generate_weekdays(start_date, end_date)
+        if not synthetic_days or len(synthetic_days) > max_gap:
+            return trading_days, []
+        return synthetic_days, synthetic_days
+
+    ordered = sorted(set(trading_days))
+    last_known = ordered[-1]
+    if last_known >= end_date:
+        return ordered, []
+
+    max_gap = max(0, _env_int(TRADING_DAY_FALLBACK_MAX_GAP_ENV, DEFAULT_TRADING_DAY_FALLBACK_MAX_GAP))
+    synthetic_days = generate_weekdays(max(last_known + _dt.timedelta(days=1), start_date), end_date)
+    if not synthetic_days or len(synthetic_days) > max_gap:
+        return ordered, []
+    return sorted(set(ordered + synthetic_days)), synthetic_days
 
 
 def _next_trading_day(trading_days: List[_dt.date], date: _dt.date) -> _dt.date | None:
@@ -430,6 +468,19 @@ def main(argv: list[str] | None = None) -> int:
         return 0
 
     trading_days = db.fetch_trading_days(start_date, end_date)
+    trading_days, synthetic_days = _extend_short_trading_calendar(
+        trading_days,
+        start_date=start_date,
+        end_date=end_date,
+    )
+    if synthetic_days:
+        print(
+            "index_calc_calendar_fallback: start={start} end={end} count={count}".format(
+                start=synthetic_days[0].isoformat(),
+                end=synthetic_days[-1].isoformat(),
+                count=len(synthetic_days),
+            )
+        )
     max_complete_date = db.fetch_calc_completion_max_date()
     start_date, trading_days, window_status = _select_calc_window(
         trading_days=trading_days,

--- a/tools/index_engine/ingest_prices.py
+++ b/tools/index_engine/ingest_prices.py
@@ -83,14 +83,18 @@ def _extend_short_trading_calendar(
     for a recently missing trading-day row without writing imputed prices.
     """
 
+    max_gap = max(0, _env_int(TRADING_DAY_FALLBACK_MAX_GAP_ENV, DEFAULT_TRADING_DAY_FALLBACK_MAX_GAP))
     if not trading_days:
-        return trading_days, []
+        synthetic_days = generate_weekdays(start_date, end_date)
+        if not synthetic_days or len(synthetic_days) > max_gap:
+            return trading_days, []
+        return synthetic_days, synthetic_days
+
     ordered = sorted(set(trading_days))
     last_known = ordered[-1]
     if last_known >= end_date:
         return ordered, []
 
-    max_gap = max(0, _env_int(TRADING_DAY_FALLBACK_MAX_GAP_ENV, DEFAULT_TRADING_DAY_FALLBACK_MAX_GAP))
     synthetic_days = generate_weekdays(max(last_known + _dt.timedelta(days=1), start_date), end_date)
     if not synthetic_days or len(synthetic_days) > max_gap:
         return ordered, []
@@ -387,14 +391,14 @@ def _run_backfill(args: argparse.Namespace) -> tuple[int, dict]:
         return 1, {}
 
     trading_days = fetch_trading_days(start_date, end_date)
-    if not trading_days:
-        print("No trading days found for requested range")
-        return 1, {}
     trading_days, synthetic_days = _extend_short_trading_calendar(
         trading_days,
         start_date=start_date,
         end_date=end_date,
     )
+    if not trading_days:
+        print("No trading days found for requested range")
+        return 1, {}
     if synthetic_days:
         print(
             "backfill_calendar_fallback: start={start} end={end} count={count}".format(
@@ -623,14 +627,14 @@ def _run_backfill_missing(args: argparse.Namespace) -> tuple[int, dict]:
         return 1, {}
 
     trading_days = fetch_trading_days(start_date, end_date)
-    if not trading_days:
-        print("No trading days found for requested range")
-        return 1, {}
     trading_days, synthetic_days = _extend_short_trading_calendar(
         trading_days,
         start_date=start_date,
         end_date=end_date,
     )
+    if not trading_days:
+        print("No trading days found for requested range")
+        return 1, {}
     if synthetic_days:
         print(
             "backfill_missing_calendar_fallback: start={start} end={end} count={count}".format(

--- a/tools/index_engine/ingest_prices.py
+++ b/tools/index_engine/ingest_prices.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 import argparse
 import datetime as _dt
 import http.client  # preload stdlib http to avoid local http shadowing
+import os
 import pathlib
 import sys
 from collections import defaultdict
@@ -17,6 +18,7 @@ for path in (REPO_ROOT, APP_PATH):
 
 from tools.oracle.env_bootstrap import load_env_files
 
+from index_engine.data_quality import generate_weekdays
 from index_engine.db import (
     fetch_constituent_tickers,
     fetch_distinct_tech100_tickers,
@@ -32,6 +34,8 @@ from providers.market_data_provider import fetch_eod_prices, fetch_single_day_ba
 
 PROVIDER = "MARKET_DATA"
 TICKER_ALIASES = {"FI": "FISV"}
+TRADING_DAY_FALLBACK_MAX_GAP_ENV = "SC_IDX_TRADING_DAY_FALLBACK_MAX_GAP"
+DEFAULT_TRADING_DAY_FALLBACK_MAX_GAP = 3
 
 
 def _normalize_ticker(value: str) -> str:
@@ -54,6 +58,43 @@ def _parse_dates(args: argparse.Namespace) -> list[_dt.date]:
         days = (end - start).days + 1
         return [start + _dt.timedelta(days=i) for i in range(days)]
     raise ValueError("Provide --date or both --start and --end")
+
+
+def _env_int(name: str, default: int) -> int:
+    raw = os.getenv(name)
+    if raw is None:
+        return default
+    try:
+        return int(raw)
+    except ValueError:
+        return default
+
+
+def _extend_short_trading_calendar(
+    trading_days: list[_dt.date],
+    *,
+    start_date: _dt.date,
+    end_date: _dt.date,
+) -> tuple[list[_dt.date], list[_dt.date]]:
+    """Extend a short cached calendar to the requested ready end date.
+
+    The pipeline reaches this helper only after provider readiness has selected
+    the target date. Extending the working calendar lets ingest fetch real bars
+    for a recently missing trading-day row without writing imputed prices.
+    """
+
+    if not trading_days:
+        return trading_days, []
+    ordered = sorted(set(trading_days))
+    last_known = ordered[-1]
+    if last_known >= end_date:
+        return ordered, []
+
+    max_gap = max(0, _env_int(TRADING_DAY_FALLBACK_MAX_GAP_ENV, DEFAULT_TRADING_DAY_FALLBACK_MAX_GAP))
+    synthetic_days = generate_weekdays(max(last_known + _dt.timedelta(days=1), start_date), end_date)
+    if not synthetic_days or len(synthetic_days) > max_gap:
+        return ordered, []
+    return sorted(set(ordered + synthetic_days)), synthetic_days
 
 
 def _split_tickers(raw: Optional[str]) -> list[str]:
@@ -349,6 +390,19 @@ def _run_backfill(args: argparse.Namespace) -> tuple[int, dict]:
     if not trading_days:
         print("No trading days found for requested range")
         return 1, {}
+    trading_days, synthetic_days = _extend_short_trading_calendar(
+        trading_days,
+        start_date=start_date,
+        end_date=end_date,
+    )
+    if synthetic_days:
+        print(
+            "backfill_calendar_fallback: start={start} end={end} count={count}".format(
+                start=synthetic_days[0].isoformat(),
+                end=synthetic_days[-1].isoformat(),
+                count=len(synthetic_days),
+            )
+        )
     last_trading_day = trading_days[-1]
 
     max_provider_calls = args.max_provider_calls
@@ -572,6 +626,19 @@ def _run_backfill_missing(args: argparse.Namespace) -> tuple[int, dict]:
     if not trading_days:
         print("No trading days found for requested range")
         return 1, {}
+    trading_days, synthetic_days = _extend_short_trading_calendar(
+        trading_days,
+        start_date=start_date,
+        end_date=end_date,
+    )
+    if synthetic_days:
+        print(
+            "backfill_missing_calendar_fallback: start={start} end={end} count={count}".format(
+                start=synthetic_days[0].isoformat(),
+                end=synthetic_days[-1].isoformat(),
+                count=len(synthetic_days),
+            )
+        )
 
     tickers = _split_tickers(args.tickers)
     impacted_by_date: dict[_dt.date, list[str]] = {}


### PR DESCRIPTION
## Summary
- Fixes the SC_IDX / TECH100 stale state where 2026-05-28 and 2026-05-29 were missed after PR #537.
- Direct VM1 diagnostics proved the market data provider had real bars for 2026-05-28 and 2026-05-29.
- VM1 now processes canonical prices, index levels, statistics, portfolio analytics, and portfolio positions through 2026-05-29.

## Changes
- Provider readiness now uses a daily-window probe and alternate configured probe symbols before declaring the provider unavailable.
- Ingest and calc tolerate a short cached calendar gap by using a bounded weekday fallback only to request real provider data, never imputation.
- Imputation is skipped when real canonical prices are already complete for the target window.
- Freshness/reporting no longer marks aligned data as failed just because target-date determination used a non-terminal calendar fallback warning.

## Testing
- `python -m py_compile app/index_engine/orchestration.py app/index_engine/run_report.py tools/index_engine/run_daily.py tools/index_engine/ingest_prices.py tools/index_engine/calc_index.py`
- `python tools/guard_forbidden_terms.py` -> passed
- `env PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python -m pytest tests/test_run_pipeline.py tests/test_run_pipeline_helpers.py tests/test_run_report.py tests/test_market_data_readiness.py tests/test_run_daily_guards.py tests/test_run_daily_selection.py tests/test_run_daily_next_missing.py tests/test_run_daily_effective_end_date.py tests/test_run_daily_trading_days.py tests/test_index_engine_ingest.py tests/test_calc_index_window.py -q` -> 58 passed

## Evidence
- CI: green on PR #538, including SC_IDX orchestration, Guard forbidden terms, sanity, lint, and VM canary checks.
- VM1 route used: OCI IP 152.67.155.253 because the hostname DNS record still points at the stale address.
- VM1 deployed commit: `b64abee8eb51fe8a068a5b49c2b7567e4c9690b1`
- VM1 pipeline command: transient systemd unit using the scheduler environment and `tools/index_engine/run_pipeline.py --restart`
- VM1 latest run id: `e41412df-de35-42f1-8df6-8b25261ee24b`
- VM1 latest report: `/opt/sustainacore-sc-idx-6d524d3004f3/tools/audit/output/pipeline_runs/sc_idx_pipeline_latest.json`
- terminal_status: `success`
- freshness_verdict: `fresh`
- failed_stage: `n/a`
- expected_target_date: `2026-05-29`
- latest_complete_date: `2026-05-29`
- canonical prices / levels / stats / portfolio analytics / portfolio positions max dates: `2026-05-29`
- Provider diagnostics, sanitized: SPY, AAPL, MSFT, and NVDA returned OK rows for both 2026-05-28 and 2026-05-29.
- Oracle read-only freshness before fix showed all tracked datasets missing both 2026-05-28 and 2026-05-29; final VM1 report shows all aligned to 2026-05-29.

## Notes / Follow-ups
- No Oracle schema changes were made.
- No same-day or future imputation was introduced. The fallback paths only request real provider bars for bounded recent weekday gaps.
- Rollback: `git revert b64abee8eb51fe8a068a5b49c2b7567e4c9690b1` plus earlier commits on this branch if reverting the whole PR.
- Human approval is required before merge/deploying to production mainline behavior.