### PR TITLE
Fix SC_IDX calendar fallback catch-up

### DIFF
--- a/app/index_engine/orchestration.py
+++ b/app/index_engine/orchestration.py
@@ -518,6 +518,21 @@ def _provider_readiness_status(
     return "NO_DATA"
 
 
+def _provider_verified_synthetic_days(
+    provider: Any,
+    probe_symbols: str | list[str],
+    synthetic_days: list[_dt.date],
+) -> tuple[list[_dt.date], list[_dt.date]]:
+    verified: list[_dt.date] = []
+    skipped: list[_dt.date] = []
+    for day in synthetic_days:
+        if _provider_readiness_status(provider, probe_symbols, day) == "OK":
+            verified.append(day)
+        else:
+            skipped.append(day)
+    return verified, skipped
+
+
 def _report_root_cause(state: PipelineGraphState) -> str | None:
     if state.get("root_cause"):
         return state["root_cause"]
@@ -745,17 +760,40 @@ class SCIdxPipelineRuntime:
             )
         )
         if synthetic_days:
+            fallback_probe_symbol = os.getenv(run_daily.PROBE_SYMBOL_ENV, "SPY")
+            fallback_probe_symbols = _readiness_probe_symbols(fallback_probe_symbol)[:1]
+            verified_synthetic_days, skipped_synthetic_days = _provider_verified_synthetic_days(
+                provider,
+                fallback_probe_symbols,
+                synthetic_days,
+            )
+            if skipped_synthetic_days:
+                warnings.append(
+                    "trading_days_weekday_fallback_skipped_no_bar:"
+                    f"start={skipped_synthetic_days[0].isoformat()} "
+                    f"end={skipped_synthetic_days[-1].isoformat()} "
+                    f"count={len(skipped_synthetic_days)}"
+                )
+            synthetic_days = verified_synthetic_days
             trading_days = fallback_trading_days
+            if synthetic_days:
+                cached_days = [day for day in trading_days if day not in set(skipped_synthetic_days)]
+                trading_days = sorted(set(cached_days + synthetic_days))
+            else:
+                trading_days = sorted(day for day in trading_days if day not in set(skipped_synthetic_days))
             calendar_max = trading_days[-1]
             candidate_end = run_daily.compute_eligible_end_date(
                 provider_latest=provider_latest,
                 today_utc=today_utc,
                 trading_days=trading_days,
             )
-            warnings.append(
-                "trading_days_weekday_fallback:"
-                f"start={synthetic_days[0].isoformat()} end={synthetic_days[-1].isoformat()} count={len(synthetic_days)}"
-            )
+            expected_target_date = candidate_end
+            expected_target_source = "weekday_fallback" if synthetic_days else "calendar"
+            if synthetic_days:
+                warnings.append(
+                    "trading_days_weekday_fallback:"
+                    f"start={synthetic_days[0].isoformat()} end={synthetic_days[-1].isoformat()} count={len(synthetic_days)}"
+                )
         if calendar_max and provider_latest and calendar_max < provider_latest:
             if not updated:
                 warnings.append(

--- a/app/providers/market_data_provider.py
+++ b/app/providers/market_data_provider.py
@@ -315,11 +315,10 @@ def _throttled_json_request(
             except urllib.error.HTTPError as exc:  # pragma: no cover - network specific
                 body = exc.read()
                 _log_http_error(request, exc, body)
+                if exc.code == 429:
+                    raise error_cls("market_data_http_error:429") from exc
                 if attempt < max_retries and exc.code in (429, 500, 502, 503, 504):
-                    if exc.code == 429:
-                        _sleep_until_window_reset()
-                    else:
-                        _sleep_backoff(attempt)
+                    _sleep_backoff(attempt)
                     continue
                 raise error_cls(f"market_data_http_error:{exc.code}") from exc
             except urllib.error.URLError as exc:  # pragma: no cover - network specific

--- a/tests/test_index_engine_ingest.py
+++ b/tests/test_index_engine_ingest.py
@@ -52,6 +52,7 @@ def test_backfill_extends_short_cached_calendar_to_ready_end(monkeypatch):
         "fetch_trading_days",
         lambda start, end: [_dt.date(2026, 5, 28)],
     )
+    monkeypatch.setattr(ingest_prices, "_provider_has_calendar_bar", lambda day: True)
     monkeypatch.setattr(ingest_prices, "fetch_impacted_tickers_for_trade_date", lambda day: ["AAPL"])
     monkeypatch.setattr(ingest_prices, "fetch_max_ok_trade_date", lambda ticker, provider: None)
 
@@ -107,6 +108,7 @@ def test_backfill_uses_bounded_weekday_when_cached_calendar_missing_target(monke
     canon_written = []
 
     monkeypatch.setattr(ingest_prices, "fetch_trading_days", lambda start, end: [])
+    monkeypatch.setattr(ingest_prices, "_provider_has_calendar_bar", lambda day: True)
     monkeypatch.setattr(ingest_prices, "fetch_impacted_tickers_for_trade_date", lambda day: ["MSFT"])
     monkeypatch.setattr(ingest_prices, "fetch_max_ok_trade_date", lambda ticker, provider: None)
 
@@ -137,3 +139,46 @@ def test_backfill_uses_bounded_weekday_when_cached_calendar_missing_target(monke
     assert [row["trade_date"] for row in raw_written] == [_dt.date(2026, 5, 29)]
     assert [row["trade_date"] for row in canon_written] == [_dt.date(2026, 5, 29)]
     assert summary["max_ok_trade_date"] == _dt.date(2026, 5, 29)
+
+
+def test_backfill_skips_synthetic_holiday_before_ready_day(monkeypatch):
+    calls = []
+    raw_written = []
+    canon_written = []
+
+    monkeypatch.setattr(ingest_prices, "fetch_trading_days", lambda start, end: [])
+    monkeypatch.setattr(
+        ingest_prices,
+        "_provider_has_calendar_bar",
+        lambda day: day == _dt.date(2026, 6, 22),
+    )
+    monkeypatch.setattr(ingest_prices, "fetch_impacted_tickers_for_trade_date", lambda day: ["NVDA"])
+    monkeypatch.setattr(ingest_prices, "fetch_max_ok_trade_date", lambda ticker, provider: None)
+
+    def fake_fetch_provider_rows(ticker, start_date, end_date):
+        calls.append((ticker, start_date, end_date))
+        return [{"ticker": ticker, "trade_date": "2026-06-22", "close": 300.0, "adj_close": 300.0}]
+
+    monkeypatch.setattr(ingest_prices, "_fetch_provider_rows", fake_fetch_provider_rows)
+    monkeypatch.setattr(ingest_prices, "upsert_prices_raw", lambda rows: raw_written.extend(rows) or len(rows))
+    monkeypatch.setattr(ingest_prices, "upsert_prices_canon", lambda rows: canon_written.extend(rows) or len(rows))
+
+    args = type(
+        "Args",
+        (),
+        {
+            "start": "2026-06-19",
+            "end": "2026-06-22",
+            "tickers": None,
+            "debug": False,
+            "max_provider_calls": None,
+        },
+    )()
+
+    code, summary = ingest_prices._run_backfill(args)
+
+    assert code == 0
+    assert calls == [("NVDA", _dt.date(2026, 6, 22), _dt.date(2026, 6, 22))]
+    assert [row["trade_date"] for row in raw_written] == [_dt.date(2026, 6, 22)]
+    assert [row["trade_date"] for row in canon_written] == [_dt.date(2026, 6, 22)]
+    assert summary["max_ok_trade_date"] == _dt.date(2026, 6, 22)

--- a/tests/test_market_data_readiness.py
+++ b/tests/test_market_data_readiness.py
@@ -1,4 +1,7 @@
 import datetime as dt
+import io
+import urllib.error
+import urllib.request
 
 import app.providers.market_data_provider as market_data_provider
 from tools.index_engine.run_daily import _probe_with_fallback
@@ -53,3 +56,32 @@ def test_fetch_eod_prices_single_day_uses_desc(monkeypatch):
     assert called_desc["count"] == 1
     assert len(result) == 1
     assert result[0]["trade_date"] == "2025-01-02"
+
+
+def test_provider_http_429_fails_without_sleep_retry(monkeypatch):
+    calls = {"urlopen": 0, "sleep": 0}
+
+    def fake_urlopen(*_args, **_kwargs):
+        calls["urlopen"] += 1
+        raise urllib.error.HTTPError(
+            url="https://example.invalid",
+            code=429,
+            msg="rate limited",
+            hdrs={},
+            fp=io.BytesIO(b"{}"),
+        )
+
+    monkeypatch.setattr(market_data_provider, "_urlopen", fake_urlopen)
+    monkeypatch.setattr(market_data_provider, "_acquire_token_blocking", lambda: None)
+    monkeypatch.setattr(market_data_provider, "_sleep_until_window_reset", lambda: calls.__setitem__("sleep", calls["sleep"] + 1))
+    monkeypatch.setattr(market_data_provider, "_sleep_backoff", lambda *_args, **_kwargs: calls.__setitem__("sleep", calls["sleep"] + 1))
+
+    request = urllib.request.Request("https://example.invalid")
+    try:
+        market_data_provider._throttled_json_request(request, max_retries=3)
+    except RuntimeError as exc:
+        assert str(exc) == "market_data_http_error:429"
+    else:
+        raise AssertionError("expected provider 429 error")
+
+    assert calls == {"urlopen": 1, "sleep": 0}

--- a/tests/test_run_pipeline.py
+++ b/tests/test_run_pipeline.py
@@ -628,6 +628,85 @@ def test_determine_target_dates_uses_alternate_probe_symbol_when_primary_missing
     assert result["context"]["ingest_required"] is True
 
 
+def test_determine_target_dates_skips_holiday_synthetic_day(monkeypatch, tmp_path):
+    trading_days = [dt.date(2026, 6, 18)]
+
+    def _fetch(_symbol, day):
+        if day == dt.date(2026, 6, 22):
+            return [{"trade_date": day.isoformat(), "close": "1"}]
+        return []
+
+    provider = SimpleNamespace(
+        fetch_api_usage=lambda: {"current_usage": 1, "plan_limit": 8},
+        fetch_single_day_bar=_fetch,
+    )
+    trading_days_module = SimpleNamespace(
+        update_trading_days_with_retry=lambda **kwargs: (False, "market_data_http_error:400")
+    )
+    fake_run_daily = SimpleNamespace(
+        PROBE_SYMBOL_ENV="SC_IDX_PROBE_SYMBOL",
+        DAILY_LIMIT_ENV="SC_IDX_MARKET_DATA_DAILY_LIMIT",
+        DAILY_BUFFER_ENV="SC_IDX_MARKET_DATA_DAILY_BUFFER",
+        BUFFER_ENV="SC_IDX_MARKET_DATA_CREDIT_BUFFER",
+        DEFAULT_DAILY_LIMIT=800,
+        DEFAULT_BUFFER=25,
+        TRADING_DAYS_RETRY_ENV="SC_IDX_TRADING_DAYS_RETRY_ATTEMPTS",
+        TRADING_DAYS_RETRY_BASE_ENV="SC_IDX_TRADING_DAYS_RETRY_BASE_SEC",
+        PROVIDER_READY_LOOKBACK_DAYS_ENV="SC_IDX_PROVIDER_READY_LOOKBACK_DAYS",
+        DEFAULT_PROVIDER_READY_LOOKBACK_DAYS=5,
+        _load_provider_module=lambda: provider,
+        _load_trading_days_module=lambda: trading_days_module,
+        _compute_daily_budget=lambda daily_limit, daily_buffer, calls_used_today: (800, 775),
+        _resolve_end_date=lambda provider, probe_symbol, today_utc: (
+            dt.date(2026, 6, 22),
+            trading_days,
+            dt.date(2026, 6, 18),
+        ),
+        derive_expected_target_date=run_daily.derive_expected_target_date,
+        select_next_missing_trading_day=run_daily.select_next_missing_trading_day,
+        _probe_with_fallback=run_daily._probe_with_fallback,
+        compute_eligible_end_date=run_daily.compute_eligible_end_date,
+    )
+    runtime = SCIdxPipelineRuntime(report_dir=tmp_path, telemetry_dir=tmp_path / "telemetry", state_store=_FakeStore())
+
+    monkeypatch.setenv("SC_IDX_READINESS_PROBE_SYMBOLS", "SPY")
+    monkeypatch.setattr(runtime, "_load_run_daily_module", lambda: fake_run_daily)
+    monkeypatch.setattr("index_engine.orchestration.fetch_calls_used_today", lambda *_args, **_kwargs: 0)
+    monkeypatch.setattr("index_engine.orchestration.engine_db.fetch_max_canon_trade_date", lambda: dt.date(2026, 6, 18))
+    monkeypatch.setattr("index_engine.orchestration.db_index_calc.fetch_max_level_date", lambda: dt.date(2026, 6, 18))
+    monkeypatch.setattr("index_engine.orchestration.db_index_calc.fetch_max_contribution_date", lambda: dt.date(2026, 6, 18))
+    monkeypatch.setattr("index_engine.orchestration.db_index_calc.fetch_max_stats_date", lambda: dt.date(2026, 6, 18))
+    monkeypatch.setattr("index_engine.orchestration.db_index_calc.fetch_calc_completion_max_date", lambda: dt.date(2026, 6, 18))
+    monkeypatch.setattr(
+        "index_engine.orchestration.db_portfolio_analytics.fetch_portfolio_analytics_max_date",
+        lambda: dt.date(2026, 6, 18),
+    )
+    monkeypatch.setattr(
+        "index_engine.orchestration.db_portfolio_analytics.fetch_portfolio_position_max_date",
+        lambda: dt.date(2026, 6, 18),
+    )
+    monkeypatch.setattr(
+        "index_engine.orchestration.db_portfolio_analytics.fetch_portfolio_opt_inputs_max_date",
+        lambda: dt.date(2026, 6, 18),
+    )
+    monkeypatch.setattr(
+        "index_engine.orchestration.db_portfolio_analytics.fetch_portfolio_completion_max_date",
+        lambda: dt.date(2026, 6, 18),
+    )
+
+    result = runtime.determine_target_dates(_state(smoke=False))
+
+    assert result["status"] == "DEGRADED"
+    assert result["context"]["ready_end_date"] == dt.date(2026, 6, 22)
+    assert result["context"]["next_missing_canon_date"] == dt.date(2026, 6, 22)
+    assert result["context"]["next_missing_calc_date"] == dt.date(2026, 6, 22)
+    assert result["context"]["next_missing_portfolio_date"] == dt.date(2026, 6, 22)
+    assert result["context"]["ingest_start_date"] == dt.date(2026, 6, 22)
+    assert result["context"]["synthetic_trading_days"] == ["2026-06-22"]
+    assert any("trading_days_weekday_fallback_skipped_no_bar" in item for item in result["warnings"])
+    assert result["context"]["ingest_required"] is True
+
+
 def test_determine_target_dates_uses_cached_calendar_when_refresh_raises(monkeypatch, tmp_path):
     trading_days = [dt.date(2026, 5, 27), dt.date(2026, 5, 28)]
     provider = SimpleNamespace(

--- a/tests/test_update_trading_days_auto.py
+++ b/tests/test_update_trading_days_auto.py
@@ -88,6 +88,50 @@ def test_auto_extend_falls_back_to_window(monkeypatch):
     assert provider.window is not None
 
 
+def test_auto_extend_falls_back_to_window_on_date_bounded_http_400(monkeypatch):
+    latest = _dt.date(2026, 6, 22)
+
+    class _ProviderDateRangeRejected:
+        def __init__(self):
+            self.window = None
+
+        def fetch_latest_eod_date(self, ticker):
+            return latest
+
+        def fetch_time_series(self, ticker, start, end):
+            raise RuntimeError("market_data_http_error:400")
+
+        def fetch_daily_window_desc(self, ticker, window):
+            self.window = window
+            return [
+                {"datetime": "2026-06-18"},
+                {"datetime": "2026-06-22"},
+            ]
+
+    provider = _ProviderDateRangeRejected()
+    calls = {"count": 0}
+
+    def fake_fetch_latest_trading_day():
+        calls["count"] += 1
+        return _dt.date(2026, 6, 18) if calls["count"] == 1 else latest
+
+    monkeypatch.setattr(update_module, "_load_provider_module", lambda: provider)
+    monkeypatch.setattr(update_module, "fetch_latest_trading_day", fake_fetch_latest_trading_day)
+    monkeypatch.setattr(update_module, "upsert_trading_days", lambda dates, source: len(dates))
+    monkeypatch.setattr(update_module, "_fetch_total_count", lambda: 10)
+
+    inserted, total, latest_eod, max_before, max_after = update_module.update_trading_days(
+        None, auto_extend=True
+    )
+
+    assert inserted == 1
+    assert total == 10
+    assert latest_eod == latest
+    assert max_before == _dt.date(2026, 6, 18)
+    assert max_after == latest
+    assert provider.window is not None
+
+
 def test_update_trading_days_retry_falls_back_on_timeout(monkeypatch):
     monkeypatch.setattr(
         update_module,

--- a/tools/index_engine/ingest_prices.py
+++ b/tools/index_engine/ingest_prices.py
@@ -70,6 +70,27 @@ def _env_int(name: str, default: int) -> int:
         return default
 
 
+def _provider_has_calendar_bar(day: _dt.date, probe_symbol: str = "SPY") -> bool:
+    try:
+        return bool(fetch_single_day_bar(probe_symbol, day))
+    except Exception as exc:
+        text = str(exc).lower()
+        if "no data" in text or "not ready" in text or "404" in text or "market_data_http_error:400" in text:
+            return False
+        raise
+
+
+def _filter_synthetic_trading_days(synthetic_days: list[_dt.date]) -> tuple[list[_dt.date], list[_dt.date]]:
+    verified: list[_dt.date] = []
+    skipped: list[_dt.date] = []
+    for day in synthetic_days:
+        if _provider_has_calendar_bar(day):
+            verified.append(day)
+        else:
+            skipped.append(day)
+    return verified, skipped
+
+
 def _extend_short_trading_calendar(
     trading_days: list[_dt.date],
     *,
@@ -88,7 +109,13 @@ def _extend_short_trading_calendar(
         synthetic_days = generate_weekdays(start_date, end_date)
         if not synthetic_days or len(synthetic_days) > max_gap:
             return trading_days, []
-        return synthetic_days, synthetic_days
+        verified_days, skipped_days = _filter_synthetic_trading_days(synthetic_days)
+        if skipped_days:
+            print(
+                "backfill_calendar_fallback_skipped_no_bar: "
+                f"start={skipped_days[0].isoformat()} end={skipped_days[-1].isoformat()} count={len(skipped_days)}"
+            )
+        return verified_days, verified_days
 
     ordered = sorted(set(trading_days))
     last_known = ordered[-1]
@@ -98,7 +125,13 @@ def _extend_short_trading_calendar(
     synthetic_days = generate_weekdays(max(last_known + _dt.timedelta(days=1), start_date), end_date)
     if not synthetic_days or len(synthetic_days) > max_gap:
         return ordered, []
-    return sorted(set(ordered + synthetic_days)), synthetic_days
+    verified_days, skipped_days = _filter_synthetic_trading_days(synthetic_days)
+    if skipped_days:
+        print(
+            "backfill_calendar_fallback_skipped_no_bar: "
+            f"start={skipped_days[0].isoformat()} end={skipped_days[-1].isoformat()} count={len(skipped_days)}"
+        )
+    return sorted(set(ordered + verified_days)), verified_days
 
 
 def _split_tickers(raw: Optional[str]) -> list[str]:

--- a/tools/index_engine/update_trading_days.py
+++ b/tools/index_engine/update_trading_days.py
@@ -34,6 +34,10 @@ def _is_market_data_403(exc: Exception) -> bool:
     return "market_data_http_error:403" in str(exc)
 
 
+def _is_market_data_400(exc: Exception) -> bool:
+    return "market_data_http_error:400" in str(exc)
+
+
 def _is_market_data_timeout(exc: Exception) -> bool:
     text = str(exc).lower()
     return any(
@@ -86,6 +90,23 @@ def _fetch_total_count() -> int:
     return 0
 
 
+def _fetch_calendar_values(provider, start: _dt.date, latest: _dt.date) -> list[dict]:
+    """Fetch calendar source rows, falling back when date-bounded requests are rejected."""
+
+    if hasattr(provider, "fetch_time_series"):
+        try:
+            return provider.fetch_time_series("SPY", start, latest)
+        except Exception as exc:
+            if not _is_market_data_400(exc) or not hasattr(provider, "fetch_daily_window_desc"):
+                raise
+
+    if hasattr(provider, "fetch_daily_window_desc"):
+        window = max(DEFAULT_WINDOW, (latest - start).days + 5)
+        window = min(window, MAX_WINDOW)
+        return provider.fetch_daily_window_desc("SPY", window=window)
+    return []
+
+
 def update_trading_days(
     start_date: _dt.date | None = None,
     *,
@@ -119,13 +140,7 @@ def update_trading_days(
         total = max_before or latest
         return inserted, 0, latest, max_before, total
 
-    values = []
-    if hasattr(provider, "fetch_time_series"):
-        values = provider.fetch_time_series("SPY", start, latest)
-    else:
-        window = max(DEFAULT_WINDOW, (latest - start).days + 5)
-        window = min(window, MAX_WINDOW)
-        values = provider.fetch_daily_window_desc("SPY", window=window)
+    values = _fetch_calendar_values(provider, start, latest)
     dates = sorted(
         {
             trade_date


### PR DESCRIPTION
## Summary
- Fix SC_IDX catch-up when the persisted trading-day calendar is stale and the market data provider rejects date-bounded calendar/range requests.
- Prevent bounded weekday fallback from treating provider no-data holidays as required trading days.
- Add fail-fast handling for provider HTTP 429 so VM1 writes an honest failed report instead of timing out inside provider retry sleeps.

## Changes
- `tools/index_engine/update_trading_days.py`: fall back to the provider descending daily window when a date-bounded calendar refresh returns sanitized HTTP 400.
- `app/index_engine/orchestration.py`: compute fallback target dates from provider-verified synthetic trading days and keep `ingest_start_date` aligned to that verified set.
- `tools/index_engine/ingest_prices.py`: filter synthetic fallback days before building the backfill range, avoiding holiday-start range requests.
- `app/providers/market_data_provider.py`: return sanitized `market_data_http_error:429` immediately instead of sleeping/retrying through provider rate limits.
- Regression tests cover calendar HTTP 400 fallback, skipped holiday synthetic days, June 22 catch-up selection, and fail-fast provider 429 behavior.

## Testing
- `python3 -m py_compile app/providers/market_data_provider.py app/index_engine/orchestration.py app/index_engine/run_report.py tools/index_engine/run_daily.py tools/index_engine/ingest_prices.py tools/index_engine/calc_index.py` -> passed
- `python3 tools/guard_forbidden_terms.py` -> passed
- `env PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 /mnt/c/codex/sustainacore/.venv/bin/python -m pytest tests/test_run_pipeline.py tests/test_run_pipeline_helpers.py tests/test_run_report.py tests/test_market_data_readiness.py tests/test_run_daily_guards.py tests/test_run_daily_selection.py tests/test_run_daily_next_missing.py tests/test_run_daily_effective_end_date.py tests/test_run_daily_trading_days.py tests/test_index_engine_ingest.py tests/test_calc_index_window.py tests/test_update_trading_days_auto.py -q` -> 65 passed
- CI: green on commit `de39c32455636f817b8c346659079cd4e36f3cf4`

## Evidence
- VM1 route used: `vm1-bot` to OCI IP `152.67.155.253` because `ai.sustainacore.org` still points at a stale address.
- VM1 runtime before fix: `/opt/sustainacore-sc-idx-6d524d3004f3`, commit `b64abee8eb51fe8a068a5b49c2b7567e4c9690b1`.
- Initial failed run: `ad5a2e47-36df-4e61-bd2f-3766af9667e0`, root cause `trading_days_behind_provider`, expected target `2026-06-22`, latest complete `2026-06-18`.
- Latest pre-fix run: `c1328b02-cd8a-48ec-b093-3ba676106ff9`, terminal status `failed`, failed stage `ingest_prices`, root cause `ingest_missing_ok_prices`, `raw_missing=50`, `raw_ok=0`, `canon_upserts=0`.
- Calendar evidence before fix: `SC_IDX_TRADING_DAYS` max date `2026-06-18`; row count `0` for `2026-06-19` and `2026-06-22`.
- Oracle freshness before fix: canonical prices and index levels max date `2026-06-18`; row count `0` for `2026-06-22`.
- Provider/range evidence from VM1 journal: provider-ready date was `2026-06-22`, but ingest range `2026-06-19..2026-06-22` returned sanitized `market_data_http_error:400` for multiple tickers.
- VM1 deployed PR commit: `de39c32455636f817b8c346659079cd4e36f3cf4`.
- VM1 validation run after fix: `336ff396-477a-4c82-bdfb-420e222fcbc6`.
- Latest report path: `/opt/sustainacore-sc-idx-6d524d3004f3/tools/audit/output/pipeline_runs/sc_idx_pipeline_latest.txt`.
- Latest terminal status: `failed`; failed stage: `determine_target_dates`; root cause: `determine_target_dates`; freshness verdict: `failed`; reason: `target_date_determination_failed`.
- Sanitized blocker evidence: provider latest-date lookup returned `market_data_http_error:429`, and the pipeline produced a bounded failed report in about 6 seconds instead of timing out.
- VM1 timer/service state after validation: `sc-idx-pipeline.timer` inactive and `sc-idx-pipeline.service` inactive to avoid repeated restart loops and quota burn while provider calls are rate-limited.

## Notes / Follow-ups
- No Oracle schema changes.
- No destructive Oracle operations.
- No same-day or future imputation.
- Rollback: `git revert de39c32455636f817b8c346659079cd4e36f3cf4 5a48ce107aba60d51dc35c9fc19bb97333b8f5e5`.
- It is safe to merge the code fix, but VM1 cannot process through `2026-06-22` until the market data provider rate limit clears; after merge/deploy, restart `sc-idx-pipeline.timer` and rerun once.
