### PR TITLE
Add SC_IDX provider quota guard

### DIFF
--- a/app/index_engine/orchestration.py
+++ b/app/index_engine/orchestration.py
@@ -455,9 +455,76 @@ def _eligible_probe_window(
 READINESS_PROBE_SYMBOLS_ENV = "SC_IDX_READINESS_PROBE_SYMBOLS"
 
 
+def _provider_rate_limit_error(exc: Exception) -> bool:
+    text = str(exc).lower()
+    return (
+        "market_data_http_error:429" in text
+        or "rate_limited" in text
+        or "rate limit" in text
+        or "credit" in text
+        or "quota" in text
+    )
+
+
 def _provider_no_data_error(exc: Exception) -> bool:
     text = str(exc).lower()
     return "no data" in text or "not ready" in text or "404" in text or "market_data_http_error:400" in text
+
+
+def _estimate_ingest_provider_calls(
+    trading_days: list[_dt.date],
+    start_date: _dt.date | None,
+    end_date: _dt.date | None,
+) -> int:
+    if start_date is None or end_date is None or start_date > end_date:
+        return 0
+    impacted: set[str] = set()
+    for day in trading_days:
+        if start_date <= day <= end_date:
+            impacted.update(engine_db.fetch_impacted_tickers_for_trade_date(day))
+    if impacted:
+        return len(impacted)
+    return len(engine_db.fetch_distinct_tech100_tickers())
+
+
+def _provider_budget_block_result(
+    *,
+    reason: str,
+    usage_current: Any,
+    usage_limit: Any,
+    usage_remaining: Any,
+    safety_buffer: int,
+    max_provider_calls: int,
+    daily_limit: int,
+    daily_buffer: int,
+    remaining_daily: int,
+    required_provider_calls: int | None = None,
+    context: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    counts = {
+        "provider_usage_current": usage_current,
+        "provider_usage_limit": usage_limit,
+        "provider_usage_remaining": usage_remaining,
+        "provider_credit_safety_buffer": safety_buffer,
+        "max_provider_calls": max_provider_calls,
+        "daily_limit": daily_limit,
+        "daily_buffer": daily_buffer,
+        "remaining_daily": remaining_daily,
+    }
+    if required_provider_calls is not None:
+        counts["required_provider_calls"] = required_provider_calls
+    result_context = dict(context or {})
+    result_context.update(counts)
+    return {
+        "status": "BLOCKED",
+        "detail": reason,
+        "error": reason,
+        "error_token": reason,
+        "counts": counts,
+        "context": result_context,
+        "remediation": "Wait for provider quota reset or increase provider quota, then rerun once.",
+        "retryable": False,
+    }
 
 
 def _readiness_probe_symbols(default_symbol: str) -> list[str]:
@@ -507,6 +574,8 @@ def _provider_readiness_status(
         try:
             status = _provider_symbol_readiness_status(provider, symbol, day)
         except Exception as exc:
+            if _provider_rate_limit_error(exc):
+                raise
             errors.append(exc)
             continue
         if status == "OK":
@@ -698,13 +767,32 @@ class SCIdxPipelineRuntime:
         probe_symbol = os.getenv(run_daily.PROBE_SYMBOL_ENV, "AAPL")
         usage_current = None
         usage_limit = None
+        provider_usage_remaining = None
         warnings: list[str] = []
         try:
             usage = provider.fetch_api_usage()
             usage_current = usage.get("current_usage")
             usage_limit = usage.get("plan_limit")
         except Exception as exc:
-            warnings.append(f"provider_usage_unavailable:{exc}")
+            reason = "provider_rate_limited" if _provider_rate_limit_error(exc) else "provider_usage_unavailable"
+            return _provider_budget_block_result(
+                reason=reason,
+                usage_current=None,
+                usage_limit=None,
+                usage_remaining=None,
+                safety_buffer=_env_int(
+                    getattr(run_daily, "PROVIDER_CREDIT_SAFETY_BUFFER_ENV", "SC_IDX_PROVIDER_CREDIT_SAFETY_BUFFER"),
+                    getattr(run_daily, "DEFAULT_PROVIDER_CREDIT_SAFETY_BUFFER", 0),
+                ),
+                max_provider_calls=0,
+                daily_limit=_env_int(run_daily.DAILY_LIMIT_ENV, run_daily.DEFAULT_DAILY_LIMIT),
+                daily_buffer=_env_int(
+                    run_daily.DAILY_BUFFER_ENV,
+                    _env_int(run_daily.BUFFER_ENV, run_daily.DEFAULT_BUFFER),
+                ),
+                remaining_daily=0,
+                context={"provider_usage_error": str(exc)},
+            )
 
         calls_used_today = fetch_calls_used_today("MARKET_DATA")
         daily_limit = _env_int(run_daily.DAILY_LIMIT_ENV, run_daily.DEFAULT_DAILY_LIMIT)
@@ -717,12 +805,52 @@ class SCIdxPipelineRuntime:
             daily_buffer=daily_buffer,
             calls_used_today=calls_used_today,
         )
-        provider_usage_remaining = None
-        if usage_limit is not None and usage_current is not None:
-            try:
+        safety_buffer = _env_int(
+            getattr(run_daily, "PROVIDER_CREDIT_SAFETY_BUFFER_ENV", "SC_IDX_PROVIDER_CREDIT_SAFETY_BUFFER"),
+            getattr(run_daily, "DEFAULT_PROVIDER_CREDIT_SAFETY_BUFFER", 0),
+        )
+        per_run_limit = _env_int(
+            getattr(run_daily, "MAX_PROVIDER_CALLS_PER_RUN_ENV", "SC_IDX_MAX_PROVIDER_CALLS_PER_RUN"),
+            getattr(run_daily, "DEFAULT_MAX_PROVIDER_CALLS_PER_RUN", 50),
+        )
+        budget_fn = getattr(run_daily, "provider_usage_budget", None)
+        if callable(budget_fn):
+            provider_usage_remaining, max_provider_calls, budget_stop_reason = budget_fn(
+                current_usage=usage_current,
+                plan_limit=usage_limit,
+                safety_buffer=safety_buffer,
+                per_run_limit=per_run_limit,
+                daily_budget=max_provider_calls,
+            )
+        else:
+            if usage_current is None or usage_limit is None:
+                provider_usage_remaining, max_provider_calls, budget_stop_reason = (
+                    None,
+                    0,
+                    "provider_usage_unavailable",
+                )
+            else:
                 provider_usage_remaining = int(usage_limit) - int(usage_current)
-            except Exception:
-                provider_usage_remaining = None
+                safe_remaining = provider_usage_remaining - max(0, safety_buffer)
+                if provider_usage_remaining <= 0:
+                    max_provider_calls, budget_stop_reason = 0, "quota_exhausted"
+                elif safe_remaining <= 0:
+                    max_provider_calls, budget_stop_reason = 0, "quota_safety_buffer"
+                else:
+                    max_provider_calls = max(0, min(safe_remaining, per_run_limit, max_provider_calls))
+                    budget_stop_reason = None
+        if budget_stop_reason:
+            return _provider_budget_block_result(
+                reason=budget_stop_reason,
+                usage_current=usage_current,
+                usage_limit=usage_limit,
+                usage_remaining=provider_usage_remaining,
+                safety_buffer=safety_buffer,
+                max_provider_calls=max_provider_calls,
+                daily_limit=daily_limit,
+                daily_buffer=daily_buffer,
+                remaining_daily=remaining_daily,
+            )
 
         refresh_attempts = max(1, _env_int(run_daily.TRADING_DAYS_RETRY_ENV, 3))
         refresh_backoff = max(0.0, _env_float(run_daily.TRADING_DAYS_RETRY_BASE_ENV, 1.0))
@@ -830,19 +958,53 @@ class SCIdxPipelineRuntime:
         next_missing_canon = run_daily.select_next_missing_trading_day(trading_days, max_canon_trade_date=max_canon_date)
         next_missing_calc = _select_next_missing_trading_day(trading_days, max_calc_complete_date)
         next_missing_portfolio = _select_next_missing_trading_day(trading_days, max_portfolio_complete_date)
+        required_provider_calls = 0
+        if candidate_end is not None and next_missing_canon is not None and next_missing_canon <= candidate_end:
+            required_provider_calls = _estimate_ingest_provider_calls(
+                trading_days,
+                next_missing_canon,
+                candidate_end,
+            )
+            if required_provider_calls > max_provider_calls:
+                return _provider_budget_block_result(
+                    reason="quota_exhausted",
+                    usage_current=usage_current,
+                    usage_limit=usage_limit,
+                    usage_remaining=provider_usage_remaining,
+                    safety_buffer=safety_buffer,
+                    max_provider_calls=max_provider_calls,
+                    daily_limit=daily_limit,
+                    daily_buffer=daily_buffer,
+                    remaining_daily=remaining_daily,
+                    required_provider_calls=required_provider_calls,
+                    context={
+                        "today_utc": today_utc,
+                        "calendar_max_date": calendar_max,
+                        "provider_latest_date": provider_latest,
+                        "candidate_end_date": candidate_end,
+                        "expected_target_date": expected_target_date,
+                        "expected_target_source": expected_target_source,
+                        "trading_days": trading_days,
+                        "synthetic_trading_days": [day.isoformat() for day in synthetic_days],
+                        "next_missing_canon_date": next_missing_canon,
+                        "next_missing_calc_date": next_missing_calc,
+                        "next_missing_portfolio_date": next_missing_portfolio,
+                        "ingest_required": False,
+                    },
+                )
         if max_provider_calls <= 0:
-            return {
-                "status": "SKIP",
-                "detail": "daily_budget_stop",
-                "terminal_status": "clean_skip",
-                "error_token": "daily_budget_stop",
-                "counts": {
-                    "calls_used_today": calls_used_today,
-                    "daily_limit": daily_limit,
-                    "daily_buffer": daily_buffer,
-                    "remaining_daily": remaining_daily,
-                },
-                "context": {
+            return _provider_budget_block_result(
+                reason="quota_exhausted",
+                usage_current=usage_current,
+                usage_limit=usage_limit,
+                usage_remaining=provider_usage_remaining,
+                safety_buffer=safety_buffer,
+                max_provider_calls=0,
+                daily_limit=daily_limit,
+                daily_buffer=daily_buffer,
+                remaining_daily=remaining_daily,
+                required_provider_calls=required_provider_calls,
+                context={
                     "calendar_max_date": calendar_max,
                     "provider_latest_date": provider_latest,
                     "candidate_end_date": candidate_end,
@@ -850,17 +1012,8 @@ class SCIdxPipelineRuntime:
                     "expected_target_source": expected_target_source,
                     "trading_days": trading_days,
                     "synthetic_trading_days": [day.isoformat() for day in synthetic_days],
-                    "calls_used_today": calls_used_today,
-                    "daily_limit": daily_limit,
-                    "daily_buffer": daily_buffer,
-                    "remaining_daily": remaining_daily,
-                    "max_provider_calls": 0,
-                    "provider_usage_current": usage_current,
-                    "provider_usage_limit": usage_limit,
-                    "provider_usage_remaining": provider_usage_remaining,
                 },
-                "remediation": "Wait for the UTC budget window to reset or raise the SC_IDX daily call limit.",
-            }
+            )
 
         if candidate_end is None and next_missing_calc is None and next_missing_portfolio is None:
             return {
@@ -1039,9 +1192,11 @@ class SCIdxPipelineRuntime:
             "ingest_required": ingest_required,
             "max_provider_calls": max_provider_calls,
             "provider_calls_remaining": max_provider_calls,
+            "required_provider_calls": required_provider_calls,
             "calls_used_today": calls_used_today,
             "daily_limit": daily_limit,
             "daily_buffer": daily_buffer,
+            "provider_credit_safety_buffer": safety_buffer,
             "remaining_daily": remaining_daily,
             "provider_usage_current": usage_current,
             "provider_usage_limit": usage_limit,
@@ -1193,6 +1348,21 @@ class SCIdxPipelineRuntime:
             and max_ok_trade_date is not None
             and max_ok_trade_date < end_date
         )
+        if summary.get("provider_rate_limited"):
+            return {
+                "status": "BLOCKED",
+                "detail": "provider_rate_limited",
+                "error": "provider_rate_limited",
+                "error_token": "provider_rate_limited",
+                "retryable": False,
+                "counts": summary,
+                "context": {
+                    "provider_calls_remaining": provider_calls_remaining,
+                    "max_canon_after_ingest": max_canon_after,
+                    "latest_ingest_end_date": end_date,
+                },
+                "remediation": "Wait for provider quota reset or increase provider quota, then rerun once.",
+            }
         if exit_code != 0:
             return {
                 "status": "FAILED",

--- a/app/providers/market_data_provider.py
+++ b/app/providers/market_data_provider.py
@@ -335,9 +335,8 @@ def _throttled_json_request(
                 continue
             raise error_cls("market_data_invalid_json") from exc
 
-        if _should_retry_rate_limit(payload) and attempt < max_retries:
-            _sleep_until_window_reset()
-            continue
+        if _should_retry_rate_limit(payload):
+            raise error_cls("market_data_rate_limited")
 
         return payload
 

--- a/tests/test_index_engine_ingest.py
+++ b/tests/test_index_engine_ingest.py
@@ -182,3 +182,38 @@ def test_backfill_skips_synthetic_holiday_before_ready_day(monkeypatch):
     assert [row["trade_date"] for row in raw_written] == [_dt.date(2026, 6, 22)]
     assert [row["trade_date"] for row in canon_written] == [_dt.date(2026, 6, 22)]
     assert summary["max_ok_trade_date"] == _dt.date(2026, 6, 22)
+
+
+def test_backfill_stops_on_provider_rate_limit_without_more_tickers(monkeypatch):
+    calls = []
+
+    monkeypatch.setattr(ingest_prices, "fetch_trading_days", lambda start, end: [_dt.date(2026, 6, 22)])
+    monkeypatch.setattr(ingest_prices, "fetch_impacted_tickers_for_trade_date", lambda day: ["AAPL", "MSFT"])
+    monkeypatch.setattr(ingest_prices, "fetch_max_ok_trade_date", lambda ticker, provider: None)
+    monkeypatch.setattr(ingest_prices, "upsert_prices_raw", lambda rows: (_ for _ in ()).throw(AssertionError("no missing rows on 429")))
+    monkeypatch.setattr(ingest_prices, "upsert_prices_canon", lambda rows: (_ for _ in ()).throw(AssertionError("no canon rows on 429")))
+
+    def fake_fetch_provider_rows(ticker, start_date, end_date):
+        calls.append((ticker, start_date, end_date))
+        raise RuntimeError("market_data_http_error:429")
+
+    monkeypatch.setattr(ingest_prices, "_fetch_provider_rows", fake_fetch_provider_rows)
+
+    args = type(
+        "Args",
+        (),
+        {
+            "start": "2026-06-22",
+            "end": "2026-06-22",
+            "tickers": None,
+            "debug": False,
+            "max_provider_calls": 10,
+        },
+    )()
+
+    code, summary = ingest_prices._run_backfill(args)
+
+    assert code == 2
+    assert summary["provider_rate_limited"] is True
+    assert summary["provider_calls_used"] == 1
+    assert calls == [("AAPL", _dt.date(2026, 6, 22), _dt.date(2026, 6, 22))]

--- a/tests/test_market_data_readiness.py
+++ b/tests/test_market_data_readiness.py
@@ -85,3 +85,36 @@ def test_provider_http_429_fails_without_sleep_retry(monkeypatch):
         raise AssertionError("expected provider 429 error")
 
     assert calls == {"urlopen": 1, "sleep": 0}
+
+
+def test_provider_payload_rate_limit_fails_without_sleep_retry(monkeypatch):
+    calls = {"urlopen": 0, "sleep": 0}
+
+    class _Response:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *_args):
+            return False
+
+        def read(self):
+            return b'{"status":"error","message":"credit limit reached"}'
+
+    def fake_urlopen(*_args, **_kwargs):
+        calls["urlopen"] += 1
+        return _Response()
+
+    monkeypatch.setattr(market_data_provider, "_urlopen", fake_urlopen)
+    monkeypatch.setattr(market_data_provider, "_acquire_token_blocking", lambda: None)
+    monkeypatch.setattr(market_data_provider, "_sleep_until_window_reset", lambda: calls.__setitem__("sleep", calls["sleep"] + 1))
+    monkeypatch.setattr(market_data_provider, "_sleep_backoff", lambda *_args, **_kwargs: calls.__setitem__("sleep", calls["sleep"] + 1))
+
+    request = urllib.request.Request("https://example.invalid")
+    try:
+        market_data_provider._throttled_json_request(request, max_retries=3)
+    except RuntimeError as exc:
+        assert str(exc) == "market_data_rate_limited"
+    else:
+        raise AssertionError("expected provider rate-limit error")
+
+    assert calls == {"urlopen": 1, "sleep": 0}

--- a/tests/test_run_pipeline.py
+++ b/tests/test_run_pipeline.py
@@ -6,6 +6,8 @@ from pathlib import Path
 import sys
 from types import SimpleNamespace
 
+import pytest
+
 REPO_ROOT = Path(__file__).resolve().parents[1]
 APP_ROOT = REPO_ROOT / "app"
 for path in (REPO_ROOT, APP_ROOT):
@@ -24,6 +26,20 @@ from index_engine.orchestration import (
 import index_engine.orchestration as orchestration
 import tools.index_engine.run_pipeline as pipeline_cli
 from tools.index_engine import run_daily
+
+
+@pytest.fixture(autouse=True)
+def _stub_provider_call_estimate(monkeypatch):
+    monkeypatch.setattr(
+        orchestration.engine_db,
+        "fetch_impacted_tickers_for_trade_date",
+        lambda _trade_date: ["AAPL"],
+    )
+    monkeypatch.setattr(
+        orchestration.engine_db,
+        "fetch_distinct_tech100_tickers",
+        lambda: ["AAPL"],
+    )
 
 
 @dataclass
@@ -398,7 +414,76 @@ def test_determine_target_dates_uses_defaults_for_blank_budget_env(monkeypatch, 
     assert result["status"] == "OK"
     assert result["context"]["daily_limit"] == 800
     assert result["context"]["daily_buffer"] == 25
-    assert result["context"]["max_provider_calls"] == 775
+    assert result["context"]["max_provider_calls"] == 7
+
+
+def test_determine_target_dates_blocks_when_provider_quota_exhausted(monkeypatch, tmp_path):
+    calls = {"resolve": 0}
+    provider = SimpleNamespace(fetch_api_usage=lambda: {"current_usage": 993, "plan_limit": 800})
+    fake_run_daily = SimpleNamespace(
+        PROBE_SYMBOL_ENV="SC_IDX_PROBE_SYMBOL",
+        DAILY_LIMIT_ENV="SC_IDX_MARKET_DATA_DAILY_LIMIT",
+        DAILY_BUFFER_ENV="SC_IDX_MARKET_DATA_DAILY_BUFFER",
+        BUFFER_ENV="SC_IDX_MARKET_DATA_CREDIT_BUFFER",
+        DEFAULT_DAILY_LIMIT=800,
+        DEFAULT_BUFFER=25,
+        PROVIDER_CREDIT_SAFETY_BUFFER_ENV="SC_IDX_PROVIDER_CREDIT_SAFETY_BUFFER",
+        DEFAULT_PROVIDER_CREDIT_SAFETY_BUFFER=100,
+        MAX_PROVIDER_CALLS_PER_RUN_ENV="SC_IDX_MAX_PROVIDER_CALLS_PER_RUN",
+        DEFAULT_MAX_PROVIDER_CALLS_PER_RUN=50,
+        _load_provider_module=lambda: provider,
+        _load_trading_days_module=lambda: SimpleNamespace(update_trading_days_with_retry=lambda **kwargs: (True, None)),
+        _compute_daily_budget=lambda daily_limit, daily_buffer, calls_used_today: (800, 775),
+        provider_usage_budget=run_daily.provider_usage_budget,
+    )
+
+    def _resolve(*_args, **_kwargs):
+        calls["resolve"] += 1
+        raise AssertionError("target resolution should not run after quota stop")
+
+    fake_run_daily._resolve_end_date = _resolve
+    runtime = SCIdxPipelineRuntime(report_dir=tmp_path, telemetry_dir=tmp_path / "telemetry", state_store=_FakeStore())
+    monkeypatch.setattr(runtime, "_load_run_daily_module", lambda: fake_run_daily)
+    monkeypatch.setattr("index_engine.orchestration.fetch_calls_used_today", lambda *_args, **_kwargs: 0)
+
+    result = runtime.determine_target_dates(_state(smoke=False))
+
+    assert result["status"] == "BLOCKED"
+    assert result["error_token"] == "quota_exhausted"
+    assert result["counts"]["provider_usage_current"] == 993
+    assert result["counts"]["provider_usage_limit"] == 800
+    assert calls["resolve"] == 0
+
+
+def test_determine_target_dates_blocks_when_remaining_below_safety_buffer(monkeypatch, tmp_path):
+    provider = SimpleNamespace(fetch_api_usage=lambda: {"current_usage": 725, "plan_limit": 800})
+    fake_run_daily = SimpleNamespace(
+        PROBE_SYMBOL_ENV="SC_IDX_PROBE_SYMBOL",
+        DAILY_LIMIT_ENV="SC_IDX_MARKET_DATA_DAILY_LIMIT",
+        DAILY_BUFFER_ENV="SC_IDX_MARKET_DATA_DAILY_BUFFER",
+        BUFFER_ENV="SC_IDX_MARKET_DATA_CREDIT_BUFFER",
+        DEFAULT_DAILY_LIMIT=800,
+        DEFAULT_BUFFER=25,
+        PROVIDER_CREDIT_SAFETY_BUFFER_ENV="SC_IDX_PROVIDER_CREDIT_SAFETY_BUFFER",
+        DEFAULT_PROVIDER_CREDIT_SAFETY_BUFFER=100,
+        MAX_PROVIDER_CALLS_PER_RUN_ENV="SC_IDX_MAX_PROVIDER_CALLS_PER_RUN",
+        DEFAULT_MAX_PROVIDER_CALLS_PER_RUN=50,
+        _load_provider_module=lambda: provider,
+        _load_trading_days_module=lambda: SimpleNamespace(update_trading_days_with_retry=lambda **kwargs: (True, None)),
+        _compute_daily_budget=lambda daily_limit, daily_buffer, calls_used_today: (800, 775),
+        provider_usage_budget=run_daily.provider_usage_budget,
+        _resolve_end_date=lambda *_args, **_kwargs: (_ for _ in ()).throw(AssertionError("no provider calls")),
+    )
+    runtime = SCIdxPipelineRuntime(report_dir=tmp_path, telemetry_dir=tmp_path / "telemetry", state_store=_FakeStore())
+    monkeypatch.setattr(runtime, "_load_run_daily_module", lambda: fake_run_daily)
+    monkeypatch.setattr("index_engine.orchestration.fetch_calls_used_today", lambda *_args, **_kwargs: 0)
+
+    result = runtime.determine_target_dates(_state(smoke=False))
+
+    assert result["status"] == "BLOCKED"
+    assert result["error_token"] == "quota_safety_buffer"
+    assert result["counts"]["provider_usage_remaining"] == 75
+    assert result["counts"]["provider_credit_safety_buffer"] == 100
 
 
 def test_determine_target_dates_clean_skips_when_provider_not_ready(monkeypatch, tmp_path):

--- a/tools/index_engine/ingest_prices.py
+++ b/tools/index_engine/ingest_prices.py
@@ -60,6 +60,17 @@ def _parse_dates(args: argparse.Namespace) -> list[_dt.date]:
     raise ValueError("Provide --date or both --start and --end")
 
 
+def _provider_rate_limit_error(exc: Exception) -> bool:
+    text = str(exc).lower()
+    return (
+        "market_data_http_error:429" in text
+        or "market_data_rate_limited" in text
+        or "rate limit" in text
+        or "quota" in text
+        or "credit" in text
+    )
+
+
 def _env_int(name: str, default: int) -> int:
     raw = os.getenv(name)
     if raw is None:
@@ -508,6 +519,24 @@ def _run_backfill(args: argparse.Namespace) -> tuple[int, dict]:
         try:
             provider_rows = _fetch_provider_rows(ticker, ticker_start, last_trading_day)
         except Exception as exc:
+            if _provider_rate_limit_error(exc):
+                print(
+                    "provider_rate_limited: provider_calls_used={calls} ticker={ticker} error={exc}".format(
+                        calls=provider_calls_used,
+                        ticker=ticker,
+                        exc=exc,
+                    )
+                )
+                return 2, {
+                    "provider_calls_used": provider_calls_used,
+                    "raw_upserts": total_raw,
+                    "canon_upserts": total_canon,
+                    "raw_ok": total_status["OK"],
+                    "raw_missing": total_status["MISSING"],
+                    "raw_error": total_status["ERROR"],
+                    "max_ok_trade_date": max_ok_trade_date,
+                    "provider_rate_limited": True,
+                }
             provider_error = str(exc)
             print(
                 "Provider fetch failed for {ticker} range={start}..{end}: {exc}".format(
@@ -748,6 +777,24 @@ def _run_backfill_missing(args: argparse.Namespace) -> tuple[int, dict]:
             try:
                 provider_rows = _fetch_provider_rows(ticker, start, end)
             except Exception as exc:
+                if _provider_rate_limit_error(exc):
+                    print(
+                        "provider_rate_limited: provider_calls_used={calls} ticker={ticker} error={exc}".format(
+                            calls=provider_calls_used,
+                            ticker=ticker,
+                            exc=exc,
+                        )
+                    )
+                    return 2, {
+                        "provider_calls_used": provider_calls_used,
+                        "raw_upserts": total_raw,
+                        "canon_upserts": total_canon,
+                        "raw_ok": total_status["OK"],
+                        "raw_missing": total_status["MISSING"],
+                        "raw_error": total_status["ERROR"],
+                        "max_ok_trade_date": max_ok_trade_date,
+                        "provider_rate_limited": True,
+                    }
                 print(
                     "Provider fetch failed for {ticker} range={start}..{end}: {exc}".format(
                         ticker=ticker,

--- a/tools/index_engine/run_daily.py
+++ b/tools/index_engine/run_daily.py
@@ -36,6 +36,10 @@ TRADING_DAYS_RETRY_BASE_ENV = "SC_IDX_TRADING_DAYS_RETRY_BASE_SEC"
 TRADING_DAY_FALLBACK_MAX_GAP_ENV = "SC_IDX_TRADING_DAY_FALLBACK_MAX_GAP"
 PROVIDER_READY_LOOKBACK_DAYS_ENV = "SC_IDX_PROVIDER_READY_LOOKBACK_DAYS"
 DEFAULT_PROVIDER_READY_LOOKBACK_DAYS = 5
+PROVIDER_CREDIT_SAFETY_BUFFER_ENV = "SC_IDX_PROVIDER_CREDIT_SAFETY_BUFFER"
+DEFAULT_PROVIDER_CREDIT_SAFETY_BUFFER = 100
+MAX_PROVIDER_CALLS_PER_RUN_ENV = "SC_IDX_MAX_PROVIDER_CALLS_PER_RUN"
+DEFAULT_MAX_PROVIDER_CALLS_PER_RUN = 50
 
 
 def _load_provider_module():
@@ -132,6 +136,29 @@ def _compute_daily_budget(daily_limit: int, daily_buffer: int, calls_used_today:
     remaining_daily = max(0, daily_limit - calls_used_today)
     max_provider_calls = max(0, remaining_daily - daily_buffer)
     return remaining_daily, max_provider_calls
+
+
+def provider_usage_budget(
+    *,
+    current_usage: int | None,
+    plan_limit: int | None,
+    safety_buffer: int,
+    per_run_limit: int,
+    daily_budget: int,
+) -> tuple[int | None, int, str | None]:
+    """Return remaining provider credits, run call budget, and a stop reason."""
+
+    if current_usage is None or plan_limit is None:
+        return None, 0, "provider_usage_unavailable"
+
+    remaining = int(plan_limit) - int(current_usage)
+    safe_remaining = remaining - max(0, safety_buffer)
+    if remaining <= 0:
+        return remaining, 0, "quota_exhausted"
+    if safe_remaining <= 0:
+        return remaining, 0, "quota_safety_buffer"
+
+    return remaining, max(0, min(safe_remaining, per_run_limit, daily_budget)), None
 
 
 def _eligible_guard_date(provider_latest: _dt.date, today_utc: _dt.date) -> _dt.date:
@@ -428,12 +455,21 @@ def main(argv: list[str] | None = None) -> int:
     except Exception as exc:
         current_usage = None
         plan_limit = None
-        print(f"warning: unable to fetch provider usage (per-minute probe only): {exc}", file=sys.stderr)
+        print(f"provider_budget_stop: provider_usage_unavailable:{exc}", file=sys.stderr)
 
     calls_used_today = fetch_calls_used_today("MARKET_DATA")
     daily_limit = _env_int(DAILY_LIMIT_ENV, DEFAULT_DAILY_LIMIT)
     daily_buffer = _env_int(DAILY_BUFFER_ENV, _env_int(BUFFER_ENV, DEFAULT_BUFFER))
     remaining_daily, max_provider_calls = _compute_daily_budget(daily_limit, daily_buffer, calls_used_today)
+    safety_buffer = _env_int(PROVIDER_CREDIT_SAFETY_BUFFER_ENV, DEFAULT_PROVIDER_CREDIT_SAFETY_BUFFER)
+    per_run_limit = _env_int(MAX_PROVIDER_CALLS_PER_RUN_ENV, DEFAULT_MAX_PROVIDER_CALLS_PER_RUN)
+    usage_remaining, max_provider_calls, budget_stop_reason = provider_usage_budget(
+        current_usage=current_usage,
+        plan_limit=plan_limit,
+        safety_buffer=safety_buffer,
+        per_run_limit=per_run_limit,
+        daily_budget=max_provider_calls,
+    )
 
     summary = {
         "run_id": run_id,
@@ -453,7 +489,7 @@ def main(argv: list[str] | None = None) -> int:
         "oracle_user": oracle_user,
         "usage_current": current_usage,
         "usage_limit": plan_limit,
-        "usage_remaining": None,
+        "usage_remaining": usage_remaining,
     }
 
     if force_fail:
@@ -492,6 +528,54 @@ def main(argv: list[str] | None = None) -> int:
         )
         _maybe_send_alert("ERROR", summary, run_id, email_on_budget_stop)
         return 1
+
+    if budget_stop_reason:
+        start_run(
+            "sc_idx_price_ingest",
+            end_date=today_utc,
+            provider="MARKET_DATA",
+            max_provider_calls=0,
+            meta={
+                "run_id": run_id,
+                "start_date": DEFAULT_START,
+                "oracle_user": oracle_user,
+                "usage_current": current_usage,
+                "usage_limit": plan_limit,
+                "usage_remaining": usage_remaining,
+                "credit_buffer": safety_buffer,
+            },
+        )
+        summary["status"] = "DAILY_BUDGET_STOP"
+        summary["error_msg"] = budget_stop_reason
+        print(
+            "provider_budget_stop: reason={reason} usage_current={current} "
+            "usage_limit={limit} usage_remaining={remaining} safety_buffer={buffer} "
+            "max_provider_calls=0".format(
+                reason=budget_stop_reason,
+                current=current_usage,
+                limit=plan_limit,
+                remaining=usage_remaining,
+                buffer=safety_buffer,
+            )
+        )
+        finish_run(
+            run_id,
+            status="DAILY_BUDGET_STOP",
+            provider_calls_used=0,
+            raw_upserts=0,
+            canon_upserts=0,
+            raw_ok=0,
+            raw_missing=0,
+            raw_error=0,
+            max_provider_calls=0,
+            usage_current=current_usage,
+            usage_limit=plan_limit,
+            usage_remaining=usage_remaining,
+            oracle_user=oracle_user,
+            error=budget_stop_reason,
+        )
+        _maybe_send_alert("DAILY_BUDGET_STOP", summary, run_id, email_on_budget_stop)
+        return 0
 
     trading_days_refresh_failed = False
     trading_days_warning = None
@@ -616,12 +700,6 @@ def main(argv: list[str] | None = None) -> int:
         print(f"latest_eod_date_spy={end_date.isoformat()}")
         return 0
 
-    usage_remaining = None
-    if plan_limit is not None and current_usage is not None:
-        try:
-            usage_remaining = int(plan_limit) - int(current_usage)
-        except Exception:
-            usage_remaining = None
     summary["usage_remaining"] = usage_remaining
     summary["end_date"] = end_date
     summary["start_date"] = start_date
@@ -638,19 +716,20 @@ def main(argv: list[str] | None = None) -> int:
             "usage_current": current_usage,
             "usage_limit": plan_limit,
             "usage_remaining": usage_remaining,
-            "credit_buffer": daily_buffer,
+            "credit_buffer": safety_buffer,
         },
     )
 
     print(
         "index_engine_daily: end={end} calls_used_today={used} remaining_daily={remaining_daily} "
-        "daily_limit={daily_limit} daily_buffer={daily_buffer} max_provider_calls={max_calls} "
+        "daily_limit={daily_limit} daily_buffer={daily_buffer} safety_buffer={safety_buffer} max_provider_calls={max_calls} "
         "minute_limit={minute_limit} minute_used={minute_used}".format(
             end=end_date.isoformat(),
             used=calls_used_today,
             remaining_daily=remaining_daily,
             daily_limit=daily_limit,
             daily_buffer=daily_buffer,
+            safety_buffer=safety_buffer,
             max_calls=max_provider_calls,
             minute_limit=plan_limit,
             minute_used=current_usage,
@@ -711,6 +790,8 @@ def main(argv: list[str] | None = None) -> int:
     status = "OK" if exit_code == 0 else "ERROR"
     summary["status"] = status
     summary["error_msg"] = error_msg
+    if summary.get("provider_rate_limited"):
+        summary["error_msg"] = "provider_rate_limited"
 
     max_ok_trade_date = summary.get("max_ok_trade_date")
     if status == "OK":

--- a/tools/index_engine/update_trading_days.py
+++ b/tools/index_engine/update_trading_days.py
@@ -38,6 +38,11 @@ def _is_market_data_400(exc: Exception) -> bool:
     return "market_data_http_error:400" in str(exc)
 
 
+def _is_market_data_rate_limited(exc: Exception) -> bool:
+    text = str(exc).lower()
+    return "market_data_http_error:429" in text or "market_data_rate_limited" in text
+
+
 def _is_market_data_timeout(exc: Exception) -> bool:
     text = str(exc).lower()
     return any(
@@ -188,6 +193,8 @@ def update_trading_days_with_retry(
             update_trading_days(auto_extend=auto_extend)
             return True, None
         except Exception as exc:
+            if _is_market_data_rate_limited(exc):
+                raise
             if _is_market_data_403(exc) or _is_market_data_timeout(exc):
                 error_token = "market_data_http_error:403" if _is_market_data_403(exc) else "market_data_timeout"
                 print(


### PR DESCRIPTION
## Summary
- Add a hard provider quota and rate-limit circuit breaker for the SC_IDX pipeline.
- Stop catch-up, calendar fallback, and ingest before symbol loops when provider credits are exhausted, near the safety buffer, or rate limited.
- Keep VM1 timers inactive until quota resets and one preflight confirms safe capacity.

## Changes
- Added a provider usage preflight that checks account usage once before ingest/catch-up work.
- Added configurable guards: `SC_IDX_PROVIDER_CREDIT_SAFETY_BUFFER` and `SC_IDX_MAX_PROVIDER_CALLS_PER_RUN`.
- Enforced fail-fast handling for HTTP 429 and provider quota/rate-limit payloads across readiness, trading-day fallback, and ingest paths.
- Added an ingest call estimate so missing catch-up windows stop before making provider calls when safe remaining credits are insufficient.
- Updated blocked reporting so quota/rate-limit stops have meaningful stage/root cause and actionable remediation.
- Added tests covering exhausted quota, low remaining credits, immediate 429 stops, no retry sleep on provider rate-limit payloads, and ingest abort after the first rate-limit response.

## Testing
- `python3 -m py_compile app/providers/market_data_provider.py app/index_engine/orchestration.py app/index_engine/run_report.py tools/index_engine/run_daily.py tools/index_engine/ingest_prices.py tools/index_engine/calc_index.py tools/index_engine/update_trading_days.py` - passed
- `python3 tools/guard_forbidden_terms.py` - passed
- `env PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 /mnt/c/codex/sustainacore/.venv/bin/python -m pytest tests/test_run_pipeline.py tests/test_run_pipeline_helpers.py tests/test_run_report.py tests/test_market_data_readiness.py tests/test_run_daily_guards.py tests/test_run_daily_selection.py tests/test_run_daily_next_missing.py tests/test_run_daily_effective_end_date.py tests/test_run_daily_trading_days.py tests/test_index_engine_ingest.py tests/test_calc_index_window.py tests/test_update_trading_days_auto.py -q` - 69 passed

## Evidence
- VM1 current main before this PR: `934abd552178f596a21f9668cb85a781fb62fff1`.
- VM1 SC_IDX timer and service were kept inactive while provider quota was over limit.
- Previous sanitized VM1 provider evidence showed `market_data_http_error:429` and provider usage above account limit.
- This PR prevents the full pipeline from running while that condition persists.

## Notes / Follow-ups
- Rollback: `git revert ac7055e`.
- After merge and deploy, run exactly one provider usage preflight. If quota remains exhausted or rate limited, keep `sc-idx-pipeline.timer` and `sc-idx-pipeline.service` inactive. If quota has reset and safe remaining credits exceed the buffer, run one pipeline attempt.
