### PR TITLE
Pace SC_IDX provider ingest calls

### DIFF
--- a/app/index_engine/orchestration.py
+++ b/app/index_engine/orchestration.py
@@ -1443,6 +1443,8 @@ class SCIdxPipelineRuntime:
             tickers=tickers_env,
             debug=False,
             max_provider_calls=max_provider_calls,
+            provider_minute_limit=context.get("provider_minute_limit"),
+            provider_calls_per_minute=context.get("provider_calls_per_minute"),
         )
 
         try:
@@ -1604,6 +1606,8 @@ class SCIdxPipelineRuntime:
                     tickers=",".join(sorted(set(missing))),
                     debug=False,
                     max_provider_calls=retry_calls,
+                    provider_minute_limit=context.get("provider_minute_limit"),
+                    provider_calls_per_minute=context.get("provider_calls_per_minute"),
                 )
                 ingest_module._run_backfill_missing(args)
                 missing = engine_db.fetch_missing_real_for_trade_date(target_day)
@@ -1689,6 +1693,8 @@ class SCIdxPipelineRuntime:
                         tickers=",".join(replacement_tickers[:replacement_calls]),
                         debug=False,
                         max_provider_calls=replacement_calls,
+                        provider_minute_limit=context.get("provider_minute_limit"),
+                        provider_calls_per_minute=context.get("provider_calls_per_minute"),
                     )
                     ingest_module._run_backfill_missing(args)
                     context["provider_calls_remaining"] = max(

--- a/tests/test_index_engine_ingest.py
+++ b/tests/test_index_engine_ingest.py
@@ -55,6 +55,7 @@ def test_backfill_extends_short_cached_calendar_to_ready_end(monkeypatch):
     monkeypatch.setattr(ingest_prices, "_provider_has_calendar_bar", lambda day: True)
     monkeypatch.setattr(ingest_prices, "fetch_impacted_tickers_for_trade_date", lambda day: ["AAPL"])
     monkeypatch.setattr(ingest_prices, "fetch_max_ok_trade_date", lambda ticker, provider: None)
+    monkeypatch.setattr(ingest_prices, "_fetch_existing_ok", lambda **kwargs: set())
 
     def fake_fetch_provider_rows(ticker, start_date, end_date):
         calls.append((ticker, start_date, end_date))
@@ -84,6 +85,7 @@ def test_backfill_extends_short_cached_calendar_to_ready_end(monkeypatch):
             "tickers": None,
             "debug": False,
             "max_provider_calls": None,
+            "provider_calls_per_minute": 100000,
         },
     )()
 
@@ -111,6 +113,7 @@ def test_backfill_uses_bounded_weekday_when_cached_calendar_missing_target(monke
     monkeypatch.setattr(ingest_prices, "_provider_has_calendar_bar", lambda day: True)
     monkeypatch.setattr(ingest_prices, "fetch_impacted_tickers_for_trade_date", lambda day: ["MSFT"])
     monkeypatch.setattr(ingest_prices, "fetch_max_ok_trade_date", lambda ticker, provider: None)
+    monkeypatch.setattr(ingest_prices, "_fetch_existing_ok", lambda **kwargs: set())
 
     def fake_fetch_provider_rows(ticker, start_date, end_date):
         calls.append((ticker, start_date, end_date))
@@ -129,6 +132,7 @@ def test_backfill_uses_bounded_weekday_when_cached_calendar_missing_target(monke
             "tickers": None,
             "debug": False,
             "max_provider_calls": None,
+            "provider_calls_per_minute": 100000,
         },
     )()
 
@@ -154,6 +158,7 @@ def test_backfill_skips_synthetic_holiday_before_ready_day(monkeypatch):
     )
     monkeypatch.setattr(ingest_prices, "fetch_impacted_tickers_for_trade_date", lambda day: ["NVDA"])
     monkeypatch.setattr(ingest_prices, "fetch_max_ok_trade_date", lambda ticker, provider: None)
+    monkeypatch.setattr(ingest_prices, "_fetch_existing_ok", lambda **kwargs: set())
 
     def fake_fetch_provider_rows(ticker, start_date, end_date):
         calls.append((ticker, start_date, end_date))
@@ -172,6 +177,7 @@ def test_backfill_skips_synthetic_holiday_before_ready_day(monkeypatch):
             "tickers": None,
             "debug": False,
             "max_provider_calls": None,
+            "provider_calls_per_minute": 100000,
         },
     )()
 
@@ -190,6 +196,7 @@ def test_backfill_stops_on_provider_rate_limit_without_more_tickers(monkeypatch)
     monkeypatch.setattr(ingest_prices, "fetch_trading_days", lambda start, end: [_dt.date(2026, 6, 22)])
     monkeypatch.setattr(ingest_prices, "fetch_impacted_tickers_for_trade_date", lambda day: ["AAPL", "MSFT"])
     monkeypatch.setattr(ingest_prices, "fetch_max_ok_trade_date", lambda ticker, provider: None)
+    monkeypatch.setattr(ingest_prices, "_fetch_existing_ok", lambda **kwargs: set())
     monkeypatch.setattr(ingest_prices, "upsert_prices_raw", lambda rows: (_ for _ in ()).throw(AssertionError("no missing rows on 429")))
     monkeypatch.setattr(ingest_prices, "upsert_prices_canon", lambda rows: (_ for _ in ()).throw(AssertionError("no canon rows on 429")))
 
@@ -208,6 +215,8 @@ def test_backfill_stops_on_provider_rate_limit_without_more_tickers(monkeypatch)
             "tickers": None,
             "debug": False,
             "max_provider_calls": 10,
+            "provider_minute_limit": 8,
+            "provider_calls_per_minute": None,
         },
     )()
 
@@ -216,4 +225,136 @@ def test_backfill_stops_on_provider_rate_limit_without_more_tickers(monkeypatch)
     assert code == 2
     assert summary["provider_rate_limited"] is True
     assert summary["provider_calls_used"] == 1
+    assert summary["effective_calls_per_minute"] == 4
     assert calls == [("AAPL", _dt.date(2026, 6, 22), _dt.date(2026, 6, 22))]
+
+
+def test_backfill_paces_calls_under_minute_limit(monkeypatch):
+    calls = []
+    sleeps = []
+    clock = {"now": 0.0}
+
+    monkeypatch.setattr(ingest_prices, "fetch_trading_days", lambda start, end: [_dt.date(2026, 6, 22)])
+    monkeypatch.setattr(ingest_prices, "fetch_impacted_tickers_for_trade_date", lambda day: ["AAPL", "MSFT"])
+    monkeypatch.setattr(ingest_prices, "_fetch_existing_ok", lambda **kwargs: set())
+    monkeypatch.setattr(ingest_prices.time, "monotonic", lambda: clock["now"])
+
+    def fake_sleep(seconds):
+        sleeps.append(seconds)
+        clock["now"] += seconds
+
+    monkeypatch.setattr(ingest_prices.time, "sleep", fake_sleep)
+
+    def fake_fetch_provider_rows(ticker, start_date, end_date):
+        calls.append((ticker, start_date, end_date))
+        return [{"ticker": ticker, "trade_date": "2026-06-22", "close": 100.0, "adj_close": 100.0}]
+
+    monkeypatch.setattr(ingest_prices, "_fetch_provider_rows", fake_fetch_provider_rows)
+    monkeypatch.setattr(ingest_prices, "upsert_prices_raw", lambda rows: len(rows))
+    monkeypatch.setattr(ingest_prices, "upsert_prices_canon", lambda rows: len(rows))
+
+    args = type(
+        "Args",
+        (),
+        {
+            "start": "2026-06-22",
+            "end": "2026-06-22",
+            "tickers": None,
+            "debug": False,
+            "max_provider_calls": None,
+            "provider_minute_limit": 8,
+            "provider_calls_per_minute": None,
+        },
+    )()
+
+    code, summary = ingest_prices._run_backfill(args)
+
+    assert code == 0
+    assert summary["effective_calls_per_minute"] == 4
+    assert len(calls) == 2
+    assert sleeps == [15.0]
+
+
+def test_backfill_skips_existing_canonical_rows(monkeypatch):
+    calls = []
+
+    monkeypatch.setattr(ingest_prices, "fetch_trading_days", lambda start, end: [_dt.date(2026, 6, 22)])
+    monkeypatch.setattr(ingest_prices, "fetch_impacted_tickers_for_trade_date", lambda day: ["AAPL", "MSFT"])
+    monkeypatch.setattr(
+        ingest_prices,
+        "_fetch_existing_ok",
+        lambda **kwargs: {("AAPL", _dt.date(2026, 6, 22))},
+    )
+
+    def fake_fetch_provider_rows(ticker, start_date, end_date):
+        calls.append((ticker, start_date, end_date))
+        return [{"ticker": ticker, "trade_date": "2026-06-22", "close": 250.0, "adj_close": 250.0}]
+
+    monkeypatch.setattr(ingest_prices, "_fetch_provider_rows", fake_fetch_provider_rows)
+    monkeypatch.setattr(ingest_prices, "upsert_prices_raw", lambda rows: len(rows))
+    monkeypatch.setattr(ingest_prices, "upsert_prices_canon", lambda rows: len(rows))
+
+    args = type(
+        "Args",
+        (),
+        {
+            "start": "2026-06-22",
+            "end": "2026-06-22",
+            "tickers": None,
+            "debug": False,
+            "max_provider_calls": None,
+            "provider_minute_limit": 8,
+            "provider_calls_per_minute": None,
+        },
+    )()
+
+    code, summary = ingest_prices._run_backfill(args)
+
+    assert code == 0
+    assert calls == [("MSFT", _dt.date(2026, 6, 22), _dt.date(2026, 6, 22))]
+    assert summary["provider_calls_used"] == 1
+
+
+def test_backfill_missing_uses_pacing_and_reports_rate(monkeypatch):
+    calls = []
+    sleeps = []
+    clock = {"now": 0.0}
+
+    monkeypatch.setattr(ingest_prices, "fetch_trading_days", lambda start, end: [_dt.date(2026, 6, 22)])
+    monkeypatch.setattr(ingest_prices, "_fetch_existing_ok", lambda **kwargs: set())
+    monkeypatch.setattr(ingest_prices.time, "monotonic", lambda: clock["now"])
+
+    def fake_sleep(seconds):
+        sleeps.append(seconds)
+        clock["now"] += seconds
+
+    monkeypatch.setattr(ingest_prices.time, "sleep", fake_sleep)
+
+    def fake_fetch_provider_rows(ticker, start_date, end_date):
+        calls.append((ticker, start_date, end_date))
+        return [{"ticker": ticker, "trade_date": "2026-06-22", "close": 300.0, "adj_close": 300.0}]
+
+    monkeypatch.setattr(ingest_prices, "_fetch_provider_rows", fake_fetch_provider_rows)
+    monkeypatch.setattr(ingest_prices, "upsert_prices_raw", lambda rows: len(rows))
+    monkeypatch.setattr(ingest_prices, "upsert_prices_canon", lambda rows: len(rows))
+
+    args = type(
+        "Args",
+        (),
+        {
+            "start": "2026-06-22",
+            "end": "2026-06-22",
+            "tickers": "AAPL,MSFT",
+            "debug": False,
+            "max_provider_calls": None,
+            "provider_minute_limit": 8,
+            "provider_calls_per_minute": None,
+        },
+    )()
+
+    code, summary = ingest_prices._run_backfill_missing(args)
+
+    assert code == 0
+    assert summary["effective_calls_per_minute"] == 4
+    assert len(calls) == 2
+    assert sleeps == [15.0]

--- a/tools/index_engine/ingest_prices.py
+++ b/tools/index_engine/ingest_prices.py
@@ -7,6 +7,7 @@ import http.client  # preload stdlib http to avoid local http shadowing
 import os
 import pathlib
 import sys
+import time
 from collections import defaultdict
 from typing import Iterable, List, Optional
 
@@ -36,6 +37,10 @@ PROVIDER = "MARKET_DATA"
 TICKER_ALIASES = {"FI": "FISV"}
 TRADING_DAY_FALLBACK_MAX_GAP_ENV = "SC_IDX_TRADING_DAY_FALLBACK_MAX_GAP"
 DEFAULT_TRADING_DAY_FALLBACK_MAX_GAP = 3
+PROVIDER_CALLS_PER_MINUTE_ENV = "SC_IDX_PROVIDER_CALLS_PER_MINUTE"
+PROVIDER_MINUTE_SAFETY_BUFFER_ENV = "SC_IDX_PROVIDER_MINUTE_SAFETY_BUFFER"
+DEFAULT_PROVIDER_CALLS_PER_MINUTE = 6
+DEFAULT_PROVIDER_MINUTE_SAFETY_BUFFER = 4
 
 
 def _normalize_ticker(value: str) -> str:
@@ -81,6 +86,49 @@ def _env_int(name: str, default: int) -> int:
         return default
 
 
+class ProviderCallPacer:
+    def __init__(self, calls_per_minute: int | None):
+        if calls_per_minute is None or calls_per_minute <= 0:
+            self.interval_sec = 0.0
+        else:
+            self.interval_sec = 60.0 / float(calls_per_minute)
+        self._last_call_at: float | None = None
+
+    def wait(self) -> None:
+        if self.interval_sec <= 0:
+            self._last_call_at = time.monotonic()
+            return
+        now = time.monotonic()
+        if self._last_call_at is not None:
+            elapsed = now - self._last_call_at
+            sleep_for = self.interval_sec - elapsed
+            if sleep_for > 0:
+                time.sleep(sleep_for)
+                now = time.monotonic()
+        self._last_call_at = now
+
+
+def _arg_int(args: argparse.Namespace, name: str) -> int | None:
+    value = getattr(args, name, None)
+    try:
+        if value is None:
+            return None
+        return int(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def _effective_calls_per_minute(args: argparse.Namespace) -> int:
+    configured = _arg_int(args, "provider_calls_per_minute")
+    if configured is None:
+        configured = _env_int(PROVIDER_CALLS_PER_MINUTE_ENV, DEFAULT_PROVIDER_CALLS_PER_MINUTE)
+    minute_limit = _arg_int(args, "provider_minute_limit")
+    minute_buffer = max(0, _env_int(PROVIDER_MINUTE_SAFETY_BUFFER_ENV, DEFAULT_PROVIDER_MINUTE_SAFETY_BUFFER))
+    if minute_limit is not None and minute_limit > 0:
+        configured = min(configured, max(1, minute_limit - minute_buffer))
+    return max(1, configured)
+
+
 def _provider_has_calendar_bar(day: _dt.date, probe_symbol: str = "SPY") -> bool:
     try:
         return bool(fetch_single_day_bar(probe_symbol, day))
@@ -91,10 +139,16 @@ def _provider_has_calendar_bar(day: _dt.date, probe_symbol: str = "SPY") -> bool
         raise
 
 
-def _filter_synthetic_trading_days(synthetic_days: list[_dt.date]) -> tuple[list[_dt.date], list[_dt.date]]:
+def _filter_synthetic_trading_days(
+    synthetic_days: list[_dt.date],
+    *,
+    pacer: ProviderCallPacer | None = None,
+) -> tuple[list[_dt.date], list[_dt.date]]:
     verified: list[_dt.date] = []
     skipped: list[_dt.date] = []
     for day in synthetic_days:
+        if pacer is not None:
+            pacer.wait()
         if _provider_has_calendar_bar(day):
             verified.append(day)
         else:
@@ -107,6 +161,7 @@ def _extend_short_trading_calendar(
     *,
     start_date: _dt.date,
     end_date: _dt.date,
+    pacer: ProviderCallPacer | None = None,
 ) -> tuple[list[_dt.date], list[_dt.date]]:
     """Extend a short cached calendar to the requested ready end date.
 
@@ -120,7 +175,7 @@ def _extend_short_trading_calendar(
         synthetic_days = generate_weekdays(start_date, end_date)
         if not synthetic_days or len(synthetic_days) > max_gap:
             return trading_days, []
-        verified_days, skipped_days = _filter_synthetic_trading_days(synthetic_days)
+        verified_days, skipped_days = _filter_synthetic_trading_days(synthetic_days, pacer=pacer)
         if skipped_days:
             print(
                 "backfill_calendar_fallback_skipped_no_bar: "
@@ -136,7 +191,7 @@ def _extend_short_trading_calendar(
     synthetic_days = generate_weekdays(max(last_known + _dt.timedelta(days=1), start_date), end_date)
     if not synthetic_days or len(synthetic_days) > max_gap:
         return ordered, []
-    verified_days, skipped_days = _filter_synthetic_trading_days(synthetic_days)
+    verified_days, skipped_days = _filter_synthetic_trading_days(synthetic_days, pacer=pacer)
     if skipped_days:
         print(
             "backfill_calendar_fallback_skipped_no_bar: "
@@ -434,11 +489,14 @@ def _run_backfill(args: argparse.Namespace) -> tuple[int, dict]:
         print("Invalid date range: end must be on or after start")
         return 1, {}
 
+    effective_calls_per_minute = _effective_calls_per_minute(args)
+    pacer = ProviderCallPacer(effective_calls_per_minute)
     trading_days = fetch_trading_days(start_date, end_date)
     trading_days, synthetic_days = _extend_short_trading_calendar(
         trading_days,
         start_date=start_date,
         end_date=end_date,
+        pacer=pacer,
     )
     if not trading_days:
         print("No trading days found for requested range")
@@ -484,6 +542,13 @@ def _run_backfill(args: argparse.Namespace) -> tuple[int, dict]:
             tickers=len(tickers),
         )
     )
+    print(f"provider_pacing: effective_calls_per_minute={effective_calls_per_minute}")
+
+    existing_ok = _fetch_existing_ok(
+        start_date=start_date,
+        end_date=last_trading_day,
+        tickers=tickers,
+    )
 
     total_raw = 0
     total_canon = 0
@@ -491,43 +556,24 @@ def _run_backfill(args: argparse.Namespace) -> tuple[int, dict]:
     provider_error: str | None = None
     max_ok_trade_date: _dt.date | None = None
 
-    for ticker in tickers:
-        if max_provider_calls is not None and provider_calls_used >= max_provider_calls:
-            print(
-                f"budget_stop: provider_calls_used={provider_calls_used} "
-                f"max_provider_calls={max_provider_calls}"
-            )
-            break
+    missing_by_ticker: dict[str, set[_dt.date]] = {}
+    for day in trading_days:
+        impacted = fetch_impacted_tickers_for_trade_date(day) if not args.tickers else tickers
+        for ticker in impacted:
+            ticker = _normalize_ticker(ticker)
+            if ticker in tickers and (ticker, day) not in existing_ok:
+                missing_by_ticker.setdefault(ticker, set()).add(day)
 
-        provider_error = None
-        try:
-            max_ok = fetch_max_ok_trade_date(ticker, PROVIDER)
-        except Exception as exc:
-            print(f"Failed to probe max date for {ticker}: {exc}")
+    for ticker, missing_dates in missing_by_ticker.items():
+        if not missing_dates:
             continue
-
-        ticker_start = start_date
-        if max_ok:
-            if max_ok >= last_trading_day:
-                continue
-            ticker_start = max(max_ok + _dt.timedelta(days=1), start_date)
-        ticker_start = _next_trading_day(trading_days, ticker_start) or ticker_start
-        if ticker_start > last_trading_day:
-            continue
-
-        provider_calls_used += 1
-        try:
-            provider_rows = _fetch_provider_rows(ticker, ticker_start, last_trading_day)
-        except Exception as exc:
-            if _provider_rate_limit_error(exc):
+        for ticker_start, ticker_end in _ranges_from_missing(trading_days, missing_dates):
+            if max_provider_calls is not None and provider_calls_used >= max_provider_calls:
                 print(
-                    "provider_rate_limited: provider_calls_used={calls} ticker={ticker} error={exc}".format(
-                        calls=provider_calls_used,
-                        ticker=ticker,
-                        exc=exc,
-                    )
+                    f"budget_stop: provider_calls_used={provider_calls_used} "
+                    f"max_provider_calls={max_provider_calls}"
                 )
-                return 2, {
+                return 0, {
                     "provider_calls_used": provider_calls_used,
                     "raw_upserts": total_raw,
                     "canon_upserts": total_canon,
@@ -535,83 +581,112 @@ def _run_backfill(args: argparse.Namespace) -> tuple[int, dict]:
                     "raw_missing": total_status["MISSING"],
                     "raw_error": total_status["ERROR"],
                     "max_ok_trade_date": max_ok_trade_date,
-                    "provider_rate_limited": True,
+                    "effective_calls_per_minute": effective_calls_per_minute,
                 }
-            provider_error = str(exc)
-            print(
-                "Provider fetch failed for {ticker} range={start}..{end}: {exc}".format(
-                    ticker=ticker,
-                    start=ticker_start.isoformat(),
-                    end=last_trading_day.isoformat(),
-                    exc=exc,
+
+            provider_error = None
+            provider_calls_used += 1
+            pacer.wait()
+            try:
+                provider_rows = _fetch_provider_rows(ticker, ticker_start, ticker_end)
+            except Exception as exc:
+                if _provider_rate_limit_error(exc):
+                    print(
+                        "provider_rate_limited: provider_calls_used={calls} ticker={ticker} "
+                        "effective_calls_per_minute={rate} error={exc}".format(
+                            calls=provider_calls_used,
+                            ticker=ticker,
+                            rate=effective_calls_per_minute,
+                            exc=exc,
+                        )
+                    )
+                    return 2, {
+                        "provider_calls_used": provider_calls_used,
+                        "raw_upserts": total_raw,
+                        "canon_upserts": total_canon,
+                        "raw_ok": total_status["OK"],
+                        "raw_missing": total_status["MISSING"],
+                        "raw_error": total_status["ERROR"],
+                        "max_ok_trade_date": max_ok_trade_date,
+                        "provider_rate_limited": True,
+                        "effective_calls_per_minute": effective_calls_per_minute,
+                    }
+                provider_error = str(exc)
+                print(
+                    "Provider fetch failed for {ticker} range={start}..{end}: {exc}".format(
+                        ticker=ticker,
+                        start=ticker_start.isoformat(),
+                        end=ticker_end.isoformat(),
+                        exc=exc,
+                    )
                 )
-            )
-            missing_rows = _build_missing_rows(
-                ticker=ticker,
-                trading_days=trading_days,
-                start_date=ticker_start,
-                end_date=last_trading_day,
-                reason="provider_error",
-            )
-            if missing_rows:
-                total_raw += upsert_prices_raw(missing_rows)
-                total_status["MISSING"] += len(missing_rows)
-            continue
-
-        if not provider_rows:
-            print(
-                "Provider returned empty payload for {ticker} range={start}..{end}".format(
+                missing_rows = _build_missing_rows(
                     ticker=ticker,
-                    start=ticker_start.isoformat(),
-                    end=last_trading_day.isoformat(),
+                    trading_days=trading_days,
+                    start_date=ticker_start,
+                    end_date=ticker_end,
+                    reason="provider_error",
                 )
-            )
-            missing_rows = _build_missing_rows(
-                ticker=ticker,
-                trading_days=trading_days,
-                start_date=ticker_start,
-                end_date=last_trading_day,
-                reason="empty_payload",
-            )
-            if missing_rows:
-                total_raw += upsert_prices_raw(missing_rows)
-                total_status["MISSING"] += len(missing_rows)
-            continue
+                if missing_rows:
+                    total_raw += upsert_prices_raw(missing_rows)
+                    total_status["MISSING"] += len(missing_rows)
+                continue
 
-        raw_rows = _build_raw_rows_from_provider(provider_rows)
-        if raw_rows:
-            total_raw += upsert_prices_raw(raw_rows)
-        for row in raw_rows:
-            status = row.get("status")
-            if status in total_status:
-                total_status[status] += 1
-            if status == "OK" and row.get("trade_date"):
-                date_value = row.get("trade_date")
-                if max_ok_trade_date is None or date_value > max_ok_trade_date:
-                    max_ok_trade_date = date_value
-        canon_rows = compute_canonical_rows(raw_rows)
-        if canon_rows:
-            total_canon += upsert_prices_canon(canon_rows)
+            if not provider_rows:
+                print(
+                    "Provider returned empty payload for {ticker} range={start}..{end}".format(
+                        ticker=ticker,
+                        start=ticker_start.isoformat(),
+                        end=ticker_end.isoformat(),
+                    )
+                )
+                missing_rows = _build_missing_rows(
+                    ticker=ticker,
+                    trading_days=trading_days,
+                    start_date=ticker_start,
+                    end_date=ticker_end,
+                    reason="empty_payload",
+                )
+                if missing_rows:
+                    total_raw += upsert_prices_raw(missing_rows)
+                    total_status["MISSING"] += len(missing_rows)
+                continue
 
-        if args.debug:
-            _print_debug(
-                dates=[ticker_start, end_date],
-                tickers_by_date=None,
-                all_tickers=[ticker],
-                provider_called=True,
-                provider_rows=provider_rows,
-                raw_rows=raw_rows,
-                canon_rows=canon_rows,
-                provider_error=provider_error,
-                oracle_user=oracle_user,
-                oracle_user_error=oracle_user_error,
-                backfill=True,
-                provider_calls_used=provider_calls_used,
-            )
+            raw_rows = _build_raw_rows_from_provider(provider_rows)
+            if raw_rows:
+                total_raw += upsert_prices_raw(raw_rows)
+            for row in raw_rows:
+                status = row.get("status")
+                if status in total_status:
+                    total_status[status] += 1
+                if status == "OK" and row.get("trade_date"):
+                    date_value = row.get("trade_date")
+                    if max_ok_trade_date is None or date_value > max_ok_trade_date:
+                        max_ok_trade_date = date_value
+            canon_rows = compute_canonical_rows(raw_rows)
+            if canon_rows:
+                total_canon += upsert_prices_canon(canon_rows)
+
+            if args.debug:
+                _print_debug(
+                    dates=[ticker_start, ticker_end],
+                    tickers_by_date=None,
+                    all_tickers=[ticker],
+                    provider_called=True,
+                    provider_rows=provider_rows,
+                    raw_rows=raw_rows,
+                    canon_rows=canon_rows,
+                    provider_error=provider_error,
+                    oracle_user=oracle_user,
+                    oracle_user_error=oracle_user_error,
+                    backfill=True,
+                    provider_calls_used=provider_calls_used,
+                )
 
     print(
-        "backfill_summary: raw_upserts={raw} canon_upserts={canon} provider_calls_used={calls}".format(
-            raw=total_raw, canon=total_canon, calls=provider_calls_used
+        "backfill_summary: raw_upserts={raw} canon_upserts={canon} provider_calls_used={calls} "
+        "effective_calls_per_minute={rate}".format(
+            raw=total_raw, canon=total_canon, calls=provider_calls_used, rate=effective_calls_per_minute
         )
     )
     summary = {
@@ -622,6 +697,7 @@ def _run_backfill(args: argparse.Namespace) -> tuple[int, dict]:
         "raw_missing": total_status["MISSING"],
         "raw_error": total_status["ERROR"],
         "max_ok_trade_date": max_ok_trade_date,
+        "effective_calls_per_minute": effective_calls_per_minute,
     }
     return 0, summary
 
@@ -656,9 +732,10 @@ def _fetch_existing_ok(
     placeholders = ",".join(f":t{i}" for i in range(len(tickers)))
     sql = (
         "SELECT ticker, trade_date "
-        "FROM sc_idx_prices_raw "
-        f"WHERE provider = '{PROVIDER}' AND status = 'OK' "
-        "AND trade_date BETWEEN :start_date AND :end_date "
+        "FROM sc_idx_prices_canon "
+        "WHERE trade_date BETWEEN :start_date AND :end_date "
+        "AND NVL(canon_adj_close_px, canon_close_px) IS NOT NULL "
+        "AND NVL(quality, 'OK') <> 'IMPUTED' "
         f"AND ticker IN ({placeholders})"
     )
     binds = {"start_date": start_date, "end_date": end_date}
@@ -688,11 +765,14 @@ def _run_backfill_missing(args: argparse.Namespace) -> tuple[int, dict]:
         print("Invalid date range: end must be on or after start")
         return 1, {}
 
+    effective_calls_per_minute = _effective_calls_per_minute(args)
+    pacer = ProviderCallPacer(effective_calls_per_minute)
     trading_days = fetch_trading_days(start_date, end_date)
     trading_days, synthetic_days = _extend_short_trading_calendar(
         trading_days,
         start_date=start_date,
         end_date=end_date,
+        pacer=pacer,
     )
     if not trading_days:
         print("No trading days found for requested range")
@@ -733,6 +813,7 @@ def _run_backfill_missing(args: argparse.Namespace) -> tuple[int, dict]:
             tickers=len(tickers),
         )
     )
+    print(f"provider_pacing: effective_calls_per_minute={effective_calls_per_minute}")
 
     existing_ok = _fetch_existing_ok(
         start_date=start_date,
@@ -771,17 +852,21 @@ def _run_backfill_missing(args: argparse.Namespace) -> tuple[int, dict]:
                     "raw_missing": total_status["MISSING"],
                     "raw_error": total_status["ERROR"],
                     "max_ok_trade_date": max_ok_trade_date,
+                    "effective_calls_per_minute": effective_calls_per_minute,
                 }
 
             provider_calls_used += 1
+            pacer.wait()
             try:
                 provider_rows = _fetch_provider_rows(ticker, start, end)
             except Exception as exc:
                 if _provider_rate_limit_error(exc):
                     print(
-                        "provider_rate_limited: provider_calls_used={calls} ticker={ticker} error={exc}".format(
+                        "provider_rate_limited: provider_calls_used={calls} ticker={ticker} "
+                        "effective_calls_per_minute={rate} error={exc}".format(
                             calls=provider_calls_used,
                             ticker=ticker,
+                            rate=effective_calls_per_minute,
                             exc=exc,
                         )
                     )
@@ -794,6 +879,7 @@ def _run_backfill_missing(args: argparse.Namespace) -> tuple[int, dict]:
                         "raw_error": total_status["ERROR"],
                         "max_ok_trade_date": max_ok_trade_date,
                         "provider_rate_limited": True,
+                        "effective_calls_per_minute": effective_calls_per_minute,
                     }
                 print(
                     "Provider fetch failed for {ticker} range={start}..{end}: {exc}".format(
@@ -851,8 +937,9 @@ def _run_backfill_missing(args: argparse.Namespace) -> tuple[int, dict]:
                 total_canon += upsert_prices_canon(canon_rows)
 
     print(
-        "backfill_missing_summary: raw_upserts={raw} canon_upserts={canon} provider_calls_used={calls}".format(
-            raw=total_raw, canon=total_canon, calls=provider_calls_used
+        "backfill_missing_summary: raw_upserts={raw} canon_upserts={canon} provider_calls_used={calls} "
+        "effective_calls_per_minute={rate}".format(
+            raw=total_raw, canon=total_canon, calls=provider_calls_used, rate=effective_calls_per_minute
         )
     )
     summary = {
@@ -863,6 +950,7 @@ def _run_backfill_missing(args: argparse.Namespace) -> tuple[int, dict]:
         "raw_missing": total_status["MISSING"],
         "raw_error": total_status["ERROR"],
         "max_ok_trade_date": max_ok_trade_date,
+        "effective_calls_per_minute": effective_calls_per_minute,
     }
     return 0, summary
 

--- a/tools/index_engine/run_daily.py
+++ b/tools/index_engine/run_daily.py
@@ -869,6 +869,8 @@ def main(argv: list[str] | None = None) -> int:
         tickers=tickers_env,
         debug=args.debug,
         max_provider_calls=max_provider_calls,
+        provider_minute_limit=minute_limit,
+        provider_calls_per_minute=None,
     )
 
     exit_code = 0


### PR DESCRIPTION
## Summary
- Pace SC_IDX ingest provider calls below the minute-rate capacity after the quota preflight passes.
- Resume catch-up from existing canonical rows so partial ingest progress is reused instead of refetched.
- Reserve provider minute capacity for preflight/readiness calls by using a conservative default effective ingest rate.

## Changes
- Added an ingest call pacer with `SC_IDX_PROVIDER_CALLS_PER_MINUTE` and `SC_IDX_PROVIDER_MINUTE_SAFETY_BUFFER` controls.
- Capped the effective ingest rate from the reported minute limit; a limit of 8 uses an effective rate of 4 by default.
- Changed resumable ingest to skip ticker/date pairs that already have real canonical prices.
- Applied pacing to normal backfill, calendar fallback probes, and missing-row backfill.
- Added tests for minute pacing, partial canonical resume, and rate-limit stop behavior.

## Testing
- `/mnt/c/codex/sustainacore/.venv/bin/python -m py_compile app/providers/market_data_provider.py app/index_engine/orchestration.py app/index_engine/run_report.py tools/index_engine/run_daily.py tools/index_engine/ingest_prices.py tools/index_engine/calc_index.py tools/index_engine/update_trading_days.py` - passed
- `/mnt/c/codex/sustainacore/.venv/bin/python tools/guard_forbidden_terms.py` - passed
- `env PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 /mnt/c/codex/sustainacore/.venv/bin/python -m pytest --rootdir=/mnt/c/codex/sustainacore-scidx-quota-guard tests/test_index_engine_ingest.py -q` - 9 passed
- `env PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 /mnt/c/codex/sustainacore/.venv/bin/python -m pytest --rootdir=/mnt/c/codex/sustainacore-scidx-quota-guard tests/test_run_pipeline.py tests/test_run_pipeline_helpers.py tests/test_run_report.py tests/test_market_data_readiness.py tests/test_run_daily_guards.py tests/test_run_daily_selection.py tests/test_run_daily_next_missing.py tests/test_run_daily_effective_end_date.py tests/test_run_daily_trading_days.py tests/test_index_engine_ingest.py tests/test_calc_index_window.py tests/test_update_trading_days_auto.py -q` - 80 passed

## Evidence
- CI: all required PR checks completed successfully on commit `78d58da8dcb1e24955f23d4f47afb7db7c102b1b`.
- VM1 deployed commit: `78d58da8dcb1e24955f23d4f47afb7db7c102b1b`.
- VM1 corrected preflight: daily 39 / 800, daily remaining 761, safety buffer 100, minute 1 / 8, max provider calls 50.
- VM1 validation run: `77bab41a-3c69-4263-8a2c-67b771afdeba`.
- Latest report: `/opt/sustainacore-sc-idx-6d524d3004f3/tools/audit/output/pipeline_runs/sc_idx_pipeline_latest.txt`.
- Terminal status: `success_with_degradation`; freshness `fresh`; alignment `aligned`; failed stage `n/a`; root cause `n/a`.
- Dates aligned to 2026-06-23: canonical, levels, stats, portfolio analytics, and portfolio positions.
- Provider calls were paced at 4/minute; the rate-limit blocker did not recur.
- VM1 timer is active and service is inactive after validation.
- Website evidence: `/tech100/index/` and `/` render Tech100 data-date values of `2026-06-23` after restarting production Gunicorn to clear process cache.

## Notes / Follow-ups
- Rollback: `git revert 78d58da`.
- The final run is degraded only because existing recovery logic recorded bounded replacement/imputation warnings; the index, stats, and portfolio surfaces are fresh and aligned.
