### PR TITLE
Fix news article mobile table overflow

### DIFF
--- a/website_django/static/css/main.css
+++ b/website_django/static/css/main.css
@@ -1743,6 +1743,7 @@ body.has-consent-banner .chat-fab {
     padding: 1.75rem;
     box-shadow: var(--shadow);
     max-width: 1100px;
+    min-width: 0;
     width: 100%;
     margin: 0 auto;
 }
@@ -1768,6 +1769,7 @@ body.has-consent-banner .chat-fab {
 
 .news-detail__body {
     margin-top: 1rem;
+    min-width: 0;
 }
 
 .news-detail__body h2 {
@@ -1795,6 +1797,7 @@ body.has-consent-banner .chat-fab {
 
 .news-detail__rich {
     word-break: break-word;
+    min-width: 0;
 }
 
 .news-detail__rich img {
@@ -1805,7 +1808,10 @@ body.has-consent-banner .chat-fab {
 }
 
 .news-detail__table-wrap {
+    width: 100%;
+    max-width: 100%;
     overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
     margin: 1rem 0;
     border: 1px solid var(--border);
     border-radius: var(--radius);
@@ -1814,7 +1820,7 @@ body.has-consent-banner .chat-fab {
 .news-detail__table-wrap table {
     width: 100%;
     border-collapse: collapse;
-    min-width: 480px;
+    min-width: 640px;
 }
 
 .news-detail__table-wrap th,
@@ -1822,10 +1828,14 @@ body.has-consent-banner .chat-fab {
     border: 1px solid var(--border);
     padding: 0.55rem 0.6rem;
     text-align: left;
+    vertical-align: top;
+    word-break: normal;
+    overflow-wrap: normal;
 }
 
 .news-detail__table-wrap thead th {
     background: var(--surface-muted);
+    white-space: nowrap;
 }
 
 .news-detail__cta {


### PR DESCRIPTION
## Summary
- Fix mobile overflow in rich news article tables.
- Keep the TECH100 July 2026 rebalance article readable on narrow screens after the content refresh.

## Changes
- Constrain the news detail article body and table wrapper with `min-width: 0` and `max-width: 100%`.
- Let wide rich-body tables scroll horizontally inside their wrapper instead of expanding the page.
- Preserve readable table cells by avoiding inherited aggressive word breaking and keeping header labels stable.

## Testing
- `git diff --check HEAD~1 HEAD` - passed.
- VM2 production Django check: `bash scripts/vm2_manage.sh check` - passed before this CSS PR.
- VM2 Playwright CSS-injection smoke on live article - passed: desktop document width 1440/1440; mobile document width 390/390; article tables remained inside scroll wrappers.

## Evidence
- Live article after data update: https://sustainacore.org/news/NEWS_ITEMS:62/
- Live news listing after data update: https://sustainacore.org/news/
- Local screenshot artifacts: `/tmp/tech100_news_screenshots_20260701T1045Z/`
- CSS injection artifacts: `/tmp/tech100_news_screenshots_20260701T1045Z/tech100_news_patched_desktop.png`, `/tmp/tech100_news_screenshots_20260701T1045Z/tech100_news_patched_mobile.png`

## Notes / Follow-ups
- Production content was already updated through the existing `update_news_item` management command; this PR only contains the CSS overflow fix.
\n\n## Preview links\n- https://preview.sustainacore.org/\n- https://sustainacore.org/\n