### PR TITLE
Fix Oracle reconstruction backup DDL

### DIFF
--- a/tests/test_repair_sc_idx_corporate_actions.py
+++ b/tests/test_repair_sc_idx_corporate_actions.py
@@ -18,10 +18,12 @@ class FakeCursor:
         self.result: list[tuple] = []
         self.fail_on = fail_on
         self.rowcount = rowcount
+        self.calls: list[tuple[str, object]] = []
 
     def execute(self, sql, binds=None):
         normalized = " ".join(sql.strip().upper().split())
         self.sql.append(normalized)
+        self.calls.append((normalized, binds))
         if self.fail_on and self.fail_on in normalized:
             raise RuntimeError("forced restoration failure")
         if "WITH P AS" in normalized:
@@ -164,6 +166,38 @@ def test_colliding_backup_tag_is_rejected(monkeypatch) -> None:
         repair.create_backups(conn, TAG, RUN_ID, START, END)
     assert not any(sql.startswith("CREATE TABLE") for sql in conn.cur.sql)
     assert conn.commits == 0
+
+
+def test_backup_ddl_uses_typed_date_literals_without_binds(monkeypatch) -> None:
+    conn = FakeConnection()
+    created: set[str] = set()
+
+    def object_exists(_conn, name):
+        if name in repair.BACKUP_OBJECTS.values():
+            return True
+        return name in created
+
+    original_execute = conn.cur.execute
+
+    def execute(sql, binds=None):
+        normalized = " ".join(sql.strip().upper().split())
+        if normalized.startswith("CREATE TABLE"):
+            created.add(normalized.split()[2])
+        return original_execute(sql, binds)
+
+    conn.cur.execute = execute
+    monkeypatch.setattr(repair, "_object_exists", object_exists)
+    monkeypatch.setattr(repair, "_count_and_range", lambda *_: (10, START, END))
+    monkeypatch.setattr(repair, "_total_count_and_range", lambda *_: (10, START, END))
+    monkeypatch.setattr(repair, "_columns", lambda *_: [("ID", "NUMBER")])
+    monkeypatch.setattr(repair, "validate_backup_set", lambda *_args, **_kwargs: complete_records())
+
+    repair.create_backups(conn, TAG, RUN_ID, START, END)
+
+    ddl_calls = [(sql, binds) for sql, binds in conn.cur.calls if sql.startswith("CREATE TABLE")]
+    assert len(ddl_calls) == len(repair.BACKUP_OBJECTS)
+    assert all(binds is None for _, binds in ddl_calls)
+    assert all("DATE '2025-01-02'" in sql and "DATE '2026-07-10'" in sql for sql, _ in ddl_calls)
 
 
 def test_backup_reuse_requires_same_manifest_run(monkeypatch) -> None:

--- a/tools/db_migrations/repair_sc_idx_corporate_actions.py
+++ b/tools/db_migrations/repair_sc_idx_corporate_actions.py
@@ -331,10 +331,14 @@ def create_backups(
         backup = names[code]
         date_column = _date_column(target)
         source_count, _, _ = _count_and_range(conn, target, date_column, start, end)
+        # Oracle does not permit bind variables in DDL (DPI-1059). These values
+        # are parsed argparse dates, so render typed DATE literals while keeping
+        # all identifiers constrained by the static backup allowlist above.
+        start_literal = f"DATE '{start.isoformat()}'"
+        end_literal = f"DATE '{end.isoformat()}'"
         cur.execute(
             f"CREATE TABLE {backup} AS SELECT * FROM {target} "
-            f"WHERE {date_column} BETWEEN :start_date AND :end_date",
-            {"start_date": start, "end_date": end},
+            f"WHERE {date_column} BETWEEN {start_literal} AND {end_literal}"
         )
         if _columns(conn, target) != _columns(conn, backup):
             raise BackupValidationError(f"backup_columns_mismatch:{target}")


### PR DESCRIPTION
## Summary
- Fix the production-blocking Oracle backup creation failure discovered during the controlled TECH100 reconstruction.
- Keep the reconstruction fail-closed before any canonical-price or derived-table mutation.

## Changes
- Render the already parsed reconstruction bounds as typed Oracle `DATE` literals in `CREATE TABLE AS SELECT` backup statements.
- Continue constraining table and date-column identifiers through the static backup allowlist.
- Add a regression test proving all backup DDL executes without bind variables and includes the exact repair range.

## Testing
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python -m pytest -q tests/test_repair_sc_idx_corporate_actions.py tests/test_index_integrity.py tests/test_corporate_actions.py` — 43 passed.
- `python tools/guard_forbidden_terms.py` — passed.
- `python -m compileall -q app/index_engine tools/index_engine tools/db_migrations` — passed.
- `git diff --check` — passed.

## Evidence
- Merged revision `f15b4436f6f73a974d3f46a60a8a052e7c6ad201` was deployed to `/opt/sustainacore-sc-idx-f15b4436f6f7`.
- Production dry-run completed with `mode=DRY_RUN`, `oracle_writes=0`, and repair range `2025-01-02` through `2026-07-10`.
- Production apply stopped during first backup DDL with `DPI-1059: bind variables are not supported in DDL statements`.
- Failure occurred before adjusted-price ingestion, canonical-price mutation, action upsert, reconstruction, or status transition.
- The SC_IDX timer remains stopped and the service is inactive.

## Notes / Follow-ups
- Do not resume production reconstruction until this Pull Request is reviewed, merged, and deployed through the versioned-release process.
- After merge, rerun the default production dry-run, stop-state checks, and the approved reconstruction command from the new merged release.
