### PR TITLE
Allow Oracle CTAS backup nullability

### DIFF
--- a/tests/test_repair_sc_idx_corporate_actions.py
+++ b/tests/test_repair_sc_idx_corporate_actions.py
@@ -89,6 +89,28 @@ def test_backup_names_are_unique_timestamp_safe() -> None:
     assert generated[:14].isdigit()
 
 
+def test_backup_columns_allow_ctas_nullability_relaxation(monkeypatch) -> None:
+    target = [("TRADE_DATE", "DATE", 7, None, None, "N")]
+    backup = [("TRADE_DATE", "DATE", 7, None, None, "Y")]
+    monkeypatch.setattr(
+        repair,
+        "_columns",
+        lambda _conn, name: target if name == "TARGET" else backup,
+    )
+    assert repair._columns_compatible(object(), "TARGET", "BACKUP")
+
+
+def test_backup_columns_reject_restore_shape_mismatch(monkeypatch) -> None:
+    target = [("TRADE_DATE", "DATE", 7, None, None, "N")]
+    backup = [("TRADE_DATE", "TIMESTAMP(6)", 11, None, 6, "Y")]
+    monkeypatch.setattr(
+        repair,
+        "_columns",
+        lambda _conn, name: target if name == "TARGET" else backup,
+    )
+    assert not repair._columns_compatible(object(), "TARGET", "BACKUP")
+
+
 def test_price_file_is_ticker_scoped(tmp_path: Path) -> None:
     path = tmp_path / "prices.csv"
     path.write_text(

--- a/tools/db_migrations/repair_sc_idx_corporate_actions.py
+++ b/tools/db_migrations/repair_sc_idx_corporate_actions.py
@@ -187,6 +187,13 @@ def _columns(conn, object_name: str) -> list[tuple[object, ...]]:
     return [tuple(row) for row in cur.fetchall()]
 
 
+def _columns_compatible(conn, target_object: str, backup_object: str) -> bool:
+    """Compare the ordered restore shape while ignoring CTAS nullability relaxation."""
+    target = _columns(conn, target_object)
+    backup = _columns(conn, backup_object)
+    return [column[:5] for column in target] == [column[:5] for column in backup]
+
+
 def _count_and_range(
     conn,
     object_name: str,
@@ -274,7 +281,7 @@ def validate_backup_set(
             raise BackupValidationError(f"production_object_missing:{record.target_object}")
         if not _object_exists(conn, record.backup_object):
             raise BackupValidationError(f"backup_object_missing:{record.backup_object}")
-        if _columns(conn, record.target_object) != _columns(conn, record.backup_object):
+        if not _columns_compatible(conn, record.target_object, record.backup_object):
             raise BackupValidationError(f"backup_columns_mismatch:{record.target_object}")
         count, minimum, maximum = _total_count_and_range(
             conn, record.backup_object, _date_column(record.target_object)
@@ -340,7 +347,7 @@ def create_backups(
             f"CREATE TABLE {backup} AS SELECT * FROM {target} "
             f"WHERE {date_column} BETWEEN {start_literal} AND {end_literal}"
         )
-        if _columns(conn, target) != _columns(conn, backup):
+        if not _columns_compatible(conn, target, backup):
             raise BackupValidationError(f"backup_columns_mismatch:{target}")
         backup_count, _, _ = _total_count_and_range(conn, backup, date_column)
         if backup_count != source_count:


### PR DESCRIPTION
## Summary
- Fix the second production-blocking backup validation defect discovered during the controlled TECH100 reconstruction.
- Preserve strict restore-shape validation while accepting Oracle CTAS nullability relaxation.

## Changes
- Compare ordered backup and target column names, types, lengths, precision, and scale.
- Ignore only the nullable metadata flag, which Oracle may relax during `CREATE TABLE AS SELECT`.
- Keep datatype and ordered-column mismatches fail-closed.
- Add regression coverage for accepted nullability relaxation and rejected restore-shape mismatch.

## Testing
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python -m pytest -q tests/test_repair_sc_idx_corporate_actions.py tests/test_index_integrity.py tests/test_corporate_actions.py` — 45 passed.
- `python tools/guard_forbidden_terms.py` — passed.
- `python -m compileall -q app/index_engine tools/index_engine tools/db_migrations` — passed.
- `git diff --check` — passed.

## Evidence
- PR #547 merge commit `f910db9ba6261ee2411a04ec93e0842f27b9602b` is deployed at `/opt/sustainacore-sc-idx-f910db9ba626`.
- Oracle preflight passed and production dry-run reported `oracle_writes=0` for `2025-01-02` through `2026-07-10`.
- Apply stopped during backup validation with `backup_columns_mismatch:SC_IDX_STATS_DAILY`, before price repair or reconstruction.
- Read-only metadata comparison showed identical ordered restore shape; only `TRADE_DATE` nullability differed (`N` on target, `Y` on CTAS backup).
- Eight uniquely tagged backup tables were created, but no complete manifest was recorded and no production history rows were changed.
- The SC_IDX timer and service remain inactive.

## Notes / Follow-ups
- Do not resume reconstruction until this Pull Request is reviewed, merged, and deployed through the versioned-release process.
- The incomplete unmanifested backup set is not eligible for reuse or rollback.
