### PR TITLE
Allow audited non-split moves in reconstruction

### DIFF
--- a/tests/test_corporate_actions.py
+++ b/tests/test_corporate_actions.py
@@ -40,6 +40,34 @@ def test_legitimate_ordinary_move_is_not_classified_as_split() -> None:
     ) is None
 
 
+def test_reviewed_rebuild_allows_and_audits_non_split_large_move(capsys) -> None:
+    calc_index.validate_price_return_sanity(
+        prev_date=dt.date(2025, 4, 8),
+        trade_date=dt.date(2025, 4, 9),
+        tickers=["AAA"],
+        prices_prev={"AAA": 151.29648},
+        prices_now={"AAA": 183.2018},
+        max_abs_return=0.20,
+        action_lookup=lambda *_: None,
+        allow_reviewed_non_split_moves=True,
+    )
+    assert "index_calc_reviewed_non_split_move" in capsys.readouterr().err
+
+
+def test_reviewed_rebuild_still_blocks_unresolved_split_candidate() -> None:
+    with pytest.raises(calc_index.IndexValidationError, match="corporate_action_confirmation_required"):
+        calc_index.validate_price_return_sanity(
+            prev_date=dt.date(2026, 7, 1),
+            trade_date=dt.date(2026, 7, 2),
+            tickers=["AAA"],
+            prices_prev={"AAA": 400.0},
+            prices_now={"AAA": 100.0},
+            max_abs_return=0.20,
+            action_lookup=lambda *_: None,
+            allow_reviewed_non_split_moves=True,
+        )
+
+
 def test_adjusted_history_must_be_economically_continuous() -> None:
     action = ConfirmedCorporateAction("AAA", dt.date(2026, 7, 2), "FORWARD_SPLIT", 4.0)
     assert adjusted_basis_is_consistent(

--- a/tools/db_migrations/repair_sc_idx_corporate_actions.py
+++ b/tools/db_migrations/repair_sc_idx_corporate_actions.py
@@ -586,6 +586,7 @@ def rebuild_official(start: dt.date, end: dt.date) -> None:
             end.isoformat(),
             "--rebuild",
             "--strict",
+            "--allow-reviewed-non-split-moves",
             "--no-preflight-self-heal",
         ],
         check=True,

--- a/tools/index_engine/calc_index.py
+++ b/tools/index_engine/calc_index.py
@@ -271,6 +271,7 @@ def validate_price_return_sanity(
     max_abs_return: float,
     action_lookup: Callable[[str, _dt.date], object | None] | None = None,
     candidate_recorder: Callable[[object], object] | None = None,
+    allow_reviewed_non_split_moves: bool = False,
 ) -> None:
     for ticker in tickers:
         p0 = prices_prev.get(ticker)
@@ -294,6 +295,14 @@ def validate_price_return_sanity(
                 previous_price=p0,
                 current_price=p1,
             )
+            if candidate is None and allow_reviewed_non_split_moves:
+                print(
+                    "index_calc_reviewed_non_split_move:"
+                    f"ticker={ticker} prev_date={prev_date.isoformat()} "
+                    f"trade_date={trade_date.isoformat()} ret_1d={ret_1d:.8f}",
+                    file=sys.stderr,
+                )
+                continue
             confirmed = action_lookup(ticker, trade_date) if candidate and action_lookup else None
             if candidate and confirmed is None and candidate_recorder:
                 candidate_recorder(candidate)
@@ -566,6 +575,11 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument("--end", help="End date YYYY-MM-DD (default: max trading day)")
     parser.add_argument("--since-base", action="store_true", help="Use base date 2025-01-02")
     parser.add_argument("--rebuild", action="store_true")
+    parser.add_argument(
+        "--allow-reviewed-non-split-moves",
+        action="store_true",
+        help="During a strict rebuild, audit and allow large moves that are not split-ratio candidates",
+    )
     parser.add_argument("--strict", action="store_true")
     parser.add_argument("--debug", action="store_true")
     parser.add_argument("--allow-close", action="store_true")
@@ -594,6 +608,8 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument("--max-tickers", type=int, default=10)
     parser.add_argument("--max-samples", type=int, default=25)
     args = parser.parse_args(argv)
+    if args.allow_reviewed_non_split_moves and not (args.rebuild and args.strict):
+        parser.error("--allow-reviewed-non-split-moves requires --rebuild and --strict")
 
     load_default_env()
 
@@ -946,6 +962,7 @@ def main(argv: list[str] | None = None) -> int:
                     max_abs_return=max_abs_constituent_return,
                     action_lookup=db_ca.fetch_confirmed_action,
                     candidate_recorder=lambda candidate: db_ca.record_pending_candidate(candidate, run_id),
+                    allow_reviewed_non_split_moves=args.allow_reviewed_non_split_moves,
                 )
             except IndexValidationError as exc:
                 finish_run(run_id, status="ERROR", error=str(exc))


### PR DESCRIPTION
## Summary
- Allow controlled strict reconstruction to proceed across audited large historical moves that are not split-ratio candidates.
- Continue failing closed for every unresolved split or reverse-split candidate.

## Changes
- Add `--allow-reviewed-non-split-moves`, valid only with `--rebuild --strict`.
- Emit an audit diagnostic for every allowed non-split large move, including ticker, dates, and return.
- Keep ordinary scheduled calculations unchanged and fail-closed.
- Have the approved corporate-action reconstruction tool enable the scoped rebuild mode.
- Add regressions proving an audited 21.09% non-split move passes while an unresolved four-for-one candidate still blocks.

## Testing
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python -m pytest -q tests/test_repair_sc_idx_corporate_actions.py tests/test_index_integrity.py tests/test_corporate_actions.py tests/test_calc_index_rebalance_guards.py` — 53 passed.
- `python tools/guard_forbidden_terms.py` — passed.
- `python -m compileall -q app/index_engine tools/index_engine tools/db_migrations` — passed.
- `git diff --check` — passed.

## Evidence
- PR #548 merge commit `3cb3de2ecb772d64339f47b43553d67d2dbdf5bd` is deployed at `/opt/sustainacore-sc-idx-3cb3de2ecb77`.
- Preflight passed; dry-run reported `oracle_writes=0` for `2025-01-02` through `2026-07-10`.
- The incomplete tag `202607121308290A29` has eight tables and zero manifest rows; it was not reused.
- Automated adjusted-history refresh made no material change and was automatically compensated (`backup_tag=202607121341588033`, `automatic_rollback=PASS`).
- The authoritative split-factor CSV path then repaired prices and reached official reconstruction.
- Reconstruction stopped on the published NXPI move from 2025-04-08 to 2025-04-09: return `0.21087946`, threshold `0.2000`, and no split-ratio candidate.
- The complete backup set `20260712134358271C`, run `ca-e21027f7-d678-468f-aaeb-88aad9eaf0f6`, restored successfully with `automatic_rollback=PASS`.
- Action status after compensation is `NOT_RECORDED`; production history remains restored; timer and service remain inactive.

## Notes / Follow-ups
- This flag is unavailable to normal incremental calculation and cannot approve ratio-like corporate-action candidates.
- Do not resume production reconstruction until this Pull Request is reviewed, merged, and deployed.
