### PR TITLE
Preserve TECH100 base state during reconstruction

### DIFF
--- a/docs/index_engine_index_calc.md
+++ b/docs/index_engine_index_calc.md
@@ -68,6 +68,9 @@ Daily levels:
 - Full-range rebuilds retain only the previous and current price maps for return and contribution
   calculations. Oracle array DML is emitted in configurable bounded batches; levels, shares, divisors,
   contributions and statistics use the same formulas and tolerances as the unbatched path.
+- When a rebuild starts on an existing base or rebalance date, its seeded holdings/divisor snapshot is
+  staged for identical repersistence before the range delete. This preserves the initial basket state;
+  it does not create a new rebalance or change shares, target weights, or divisor mathematics.
 
 Stats lookback windows:
 

--- a/docs/index_engine_index_calc.md
+++ b/docs/index_engine_index_calc.md
@@ -69,7 +69,7 @@ Daily levels:
   calculations. Oracle array DML is emitted in configurable bounded batches; levels, shares, divisors,
   contributions and statistics use the same formulas and tolerances as the unbatched path.
 - When a rebuild starts on an existing base or rebalance date, its seeded holdings/divisor snapshot is
-  staged for identical repersistence before the range delete. This preserves the initial basket state;
+  staged to be written back unchanged after the range delete. This preserves the initial basket state;
   it does not create a new rebalance or change shares, target weights, or divisor mathematics.
 
 Stats lookback windows:

--- a/docs/runbooks/corporate_action_reconstruction.md
+++ b/docs/runbooks/corporate_action_reconstruction.md
@@ -203,6 +203,8 @@ a partial restoration. Leave the timer stopped and preserve every backup table a
 ## Required verification
 
 - CRWD has no split-only loss and no duplicate adjustment.
+- Missing prior level/divisor state is reported separately from genuinely missing exact canonical
+  rebalance anchors; both conditions remain fail-closed.
 - `market_value = shares * price_used` within 1e-6.
 - daily index return equals summed contributions within 1e-6.
 - every rebalance bridge agrees with the prior level within max(1e-6, level × 1e-8).

--- a/tests/test_calc_index_rebalance_guards.py
+++ b/tests/test_calc_index_rebalance_guards.py
@@ -90,6 +90,172 @@ def test_rebalance_anchor_retry_is_limited_to_strict_rebuild() -> None:
     assert not ci.should_retry_rebalance_anchor(rebuild=False, strict=False)
 
 
+def test_base_date_seed_is_staged_before_rebuild_delete() -> None:
+    base_date = dt.date(2025, 1, 2)
+    shares = {f"T{number:02d}": float(number + 1) for number in range(25)}
+    pending_holdings: dict[dt.date, list[dict]] = {}
+    pending_divisors: dict[dt.date, float] = {}
+
+    ci._stage_seeded_rebalance_for_rebuild(
+        rebuild=True,
+        trading_days=[base_date, dt.date(2025, 1, 3)],
+        current_reb=base_date,
+        holdings_by_reb={base_date: shares},
+        divisors_by_reb={base_date: 1.0},
+        pending_holdings_rows=pending_holdings,
+        pending_divisor_rows=pending_divisors,
+    )
+
+    assert pending_divisors == {base_date: 1.0}
+    assert len(pending_holdings[base_date]) == 25
+    assert {row["ticker"] for row in pending_holdings[base_date]} == set(shares)
+    assert sum(row["target_weight"] for row in pending_holdings[base_date]) == pytest.approx(1.0)
+    assert {row["ticker"]: row["shares"] for row in pending_holdings[base_date]} == shares
+
+
+def test_seed_before_rebuild_window_is_not_rewritten() -> None:
+    prior_rebalance = dt.date(2025, 1, 2)
+    pending_holdings: dict[dt.date, list[dict]] = {}
+    pending_divisors: dict[dt.date, float] = {}
+
+    ci._stage_seeded_rebalance_for_rebuild(
+        rebuild=True,
+        trading_days=[dt.date(2025, 1, 3)],
+        current_reb=prior_rebalance,
+        holdings_by_reb={prior_rebalance: {"AAA": 10.0}},
+        divisors_by_reb={prior_rebalance: 1.0},
+        pending_holdings_rows=pending_holdings,
+        pending_divisor_rows=pending_divisors,
+    )
+
+    assert pending_holdings == {}
+    assert pending_divisors == {}
+
+
+def test_seeded_rebalance_in_delete_window_requires_complete_state() -> None:
+    base_date = dt.date(2025, 1, 2)
+    with pytest.raises(RuntimeError, match="seeded_rebalance_state_incomplete"):
+        ci._stage_seeded_rebalance_for_rebuild(
+            rebuild=True,
+            trading_days=[base_date],
+            current_reb=base_date,
+            holdings_by_reb={base_date: {"AAA": 10.0}},
+            divisors_by_reb={},
+            pending_holdings_rows={},
+            pending_divisor_rows={},
+        )
+
+
+def test_full_rebuild_repersist_seeded_base_snapshot_across_60_dates(monkeypatch) -> None:
+    base_date = dt.date(2025, 1, 2)
+    trading_days: list[dt.date] = []
+    candidate = base_date
+    while len(trading_days) < 60:
+        if candidate.weekday() < 5:
+            trading_days.append(candidate)
+        candidate += dt.timedelta(days=1)
+    end_date = trading_days[-1]
+    shares = {"AAA": 10.0, "BBB": 5.0}
+    writes: list[tuple[str, object]] = []
+
+    monkeypatch.setattr(ci, "load_default_env", lambda: None)
+    monkeypatch.setattr(ci, "start_run", lambda *args, **kwargs: "read-only-test")
+    monkeypatch.setattr(ci, "finish_run", lambda *args, **kwargs: None)
+    monkeypatch.setattr(ci.db, "fetch_trading_days", lambda start, end: trading_days)
+    monkeypatch.setattr(ci.db, "fetch_calc_completion_max_date", lambda: end_date)
+    monkeypatch.setattr(ci.engine_db, "fetch_max_canon_trade_date", lambda: end_date)
+    monkeypatch.setattr(
+        ci,
+        "_seed_prior_state",
+        lambda **kwargs: (
+            None,
+            base_date,
+            base_date,
+            {base_date: shares},
+            {base_date: 1.0},
+            {},
+        ),
+    )
+    monkeypatch.setattr(ci.db, "fetch_universe", lambda date: (base_date, list(shares)))
+    def fetch_prices(date, tickers, **kwargs):
+        factor = 1.0 + trading_days.index(date) / 10_000
+        return {
+            "AAA": {"price": 50.0 * factor, "quality": "REAL"},
+            "BBB": {"price": 100.0 * factor, "quality": "REAL"},
+        }
+
+    monkeypatch.setattr(ci.db, "fetch_prices", fetch_prices)
+    monkeypatch.setattr(ci.db, "fetch_trading_days_before", lambda start, limit: [])
+    monkeypatch.setattr(ci.db, "delete_index_range", lambda *args: writes.append(("delete_range", args)))
+    monkeypatch.setattr(
+        ci.db,
+        "delete_holdings_divisor",
+        lambda dates: writes.append(("delete_holdings", list(dates))),
+    )
+    monkeypatch.setattr(
+        ci.db,
+        "upsert_holdings",
+        lambda date, rows: writes.append(("upsert_holdings", (date, list(rows)))),
+    )
+    monkeypatch.setattr(
+        ci.db,
+        "upsert_divisor",
+        lambda date, divisor, reason=None: writes.append(("upsert_divisor", (date, divisor))),
+    )
+    for name in (
+        "upsert_constituent_daily",
+        "upsert_levels",
+        "upsert_contribution_daily",
+        "upsert_stats_daily",
+    ):
+        monkeypatch.setattr(ci.db, name, lambda rows, name=name: writes.append((name, list(rows))))
+
+    code = ci.main(
+        [
+            "--start",
+            base_date.isoformat(),
+            "--end",
+            end_date.isoformat(),
+            "--rebuild",
+            "--strict",
+            "--no-preflight-self-heal",
+            "--no-diagnose-missing",
+        ]
+    )
+
+    assert code == 0
+    delete_position = next(i for i, item in enumerate(writes) if item[0] == "delete_holdings")
+    holding_position = next(i for i, item in enumerate(writes) if item[0] == "upsert_holdings")
+    divisor_position = next(i for i, item in enumerate(writes) if item[0] == "upsert_divisor")
+    assert delete_position < holding_position < divisor_position
+    holding_date, holding_rows = writes[holding_position][1]
+    assert holding_date == base_date
+    assert {row["ticker"]: row["shares"] for row in holding_rows} == shares
+    constituent_rows = next(item[1] for item in writes if item[0] == "upsert_constituent_daily")
+    contribution_rows = next(item[1] for item in writes if item[0] == "upsert_contribution_daily")
+    assert len(constituent_rows) == 60 * len(shares)
+    assert len(contribution_rows) == 59 * len(shares)
+
+    persisted_holdings = {holding_date: holding_rows}
+    constituent_counts = {
+        day: sum(row["trade_date"] == day for row in constituent_rows) for day in trading_days
+    }
+    contribution_counts = {
+        day: sum(row["trade_date"] == day for row in contribution_rows) for day in trading_days
+    }
+    partial_dates = []
+    for day in trading_days:
+        active = max(rebalance for rebalance in persisted_holdings if rebalance <= day)
+        expected = len(persisted_holdings[active])
+        if constituent_counts[day] != expected:
+            partial_dates.append(day)
+        elif day == base_date and contribution_counts[day] != 0:
+            partial_dates.append(day)
+        elif day > base_date and contribution_counts[day] != expected:
+            partial_dates.append(day)
+    assert partial_dates == []
+
+
 def test_stale_historical_anchor_is_rejected_for_rebalance() -> None:
     with pytest.raises(ci.IndexValidationError, match="rebalance_prior_price_stale_anchor"):
         ci.validate_rebalance_prior_prices(

--- a/tests/test_index_integrity.py
+++ b/tests/test_index_integrity.py
@@ -9,6 +9,7 @@ from app.index_engine.index_integrity import (
     maximum_check,
     rebalance_bridge_residual,
 )
+from tools.index_engine.verify_index_integrity import _rebalance_checks
 
 
 def test_contribution_sum_reconciles() -> None:
@@ -68,3 +69,49 @@ def test_stale_rebalance_anchor_fails_verification() -> None:
 def test_rebalance_bridge_requires_all_prices() -> None:
     with pytest.raises(ValueError, match="missing_prices"):
         rebalance_bridge_residual(previous_level=1000, divisor=1, shares={"A": 1}, prices={})
+
+
+class _MissingBaseDivisorCursor:
+    def __init__(self) -> None:
+        self.sql = ""
+
+    def execute(self, sql, binds=None) -> None:
+        self.sql = " ".join(sql.split())
+
+    def fetchone(self):
+        if "MAX(trade_date)" in self.sql:
+            return (dt.date(2025, 3, 31),)
+        if "SELECT level_tr" in self.sql:
+            return (1000.0,)
+        if "SELECT divisor" in self.sql and "effective_date=(" in self.sql:
+            return (None,)
+        if "SELECT divisor" in self.sql:
+            return (1.0,)
+        raise AssertionError(self.sql)
+
+    def fetchall(self):
+        if "SELECT DISTINCT rebalance_date" in self.sql:
+            return [(dt.date(2025, 4, 1),)]
+        if "SELECT ticker,target_weight,shares" in self.sql:
+            return [(f"T{number:02d}", 0.04, 1.0) for number in range(25)]
+        if "SELECT ticker,canon_adj_close_px" in self.sql:
+            return [(f"T{number:02d}", 100.0) for number in range(25)]
+        raise AssertionError(self.sql)
+
+
+def test_missing_rebalance_state_is_not_misreported_as_25_missing_prices() -> None:
+    checks = _rebalance_checks(
+        _MissingBaseDivisorCursor(),
+        start=dt.date(2025, 1, 2),
+        end=dt.date(2026, 7, 10),
+        bridge_tolerance=1e-6,
+        anchor_tolerance=1e-8,
+    )
+    by_name = {check.name: check for check in checks}
+
+    assert by_name["rebalance_missing_exact_prices"].value == 0
+    assert by_name["rebalance_missing_exact_prices"].passed
+    state = by_name["rebalance_missing_state_prerequisites"]
+    assert state.value == 1
+    assert not state.passed
+    assert state.detail == "2025-04-01:previous_divisor"

--- a/tools/index_engine/calc_index.py
+++ b/tools/index_engine/calc_index.py
@@ -213,6 +213,41 @@ def _seed_prior_state(
     return prev_trade, current_reb, prev_port_date, holdings_by_reb, divisors_by_reb, levels
 
 
+def _stage_seeded_rebalance_for_rebuild(
+    *,
+    rebuild: bool,
+    trading_days: List[_dt.date],
+    current_reb: _dt.date | None,
+    holdings_by_reb: Dict[_dt.date, Dict[str, float]],
+    divisors_by_reb: Dict[_dt.date, float],
+    pending_holdings_rows: Dict[_dt.date, list[dict]],
+    pending_divisor_rows: Dict[_dt.date, float],
+) -> None:
+    """Retain a seeded snapshot that the bounded rebuild will delete.
+
+    A base-date rebuild can seed its initial holdings and divisor from the
+    existing row.  The later range delete includes that same date, so the
+    snapshot must be staged for identical repersistence even though the
+    universe does not transition on the first calculation day.
+    """
+
+    if not rebuild or current_reb is None or current_reb not in trading_days:
+        return
+    shares = holdings_by_reb.get(current_reb)
+    divisor = divisors_by_reb.get(current_reb)
+    if not shares or divisor is None:
+        raise RuntimeError(f"seeded_rebalance_state_incomplete:{current_reb.isoformat()}")
+    target_weight = 1.0 / len(shares)
+    pending_holdings_rows.setdefault(
+        current_reb,
+        [
+            {"ticker": ticker, "target_weight": target_weight, "shares": share_count}
+            for ticker, share_count in shares.items()
+        ],
+    )
+    pending_divisor_rows.setdefault(current_reb, divisor)
+
+
 def _collect_missing(
     trade_date: _dt.date,
     tickers: List[str],
@@ -863,6 +898,15 @@ def main(argv: list[str] | None = None) -> int:
         prev_trade, current_reb, prev_port_date, holdings_by_reb, divisors_by_reb, levels = _seed_prior_state(
             start_date=trading_days[0],
             allow_close=args.allow_close,
+        )
+        _stage_seeded_rebalance_for_rebuild(
+            rebuild=args.rebuild,
+            trading_days=trading_days,
+            current_reb=current_reb,
+            holdings_by_reb=holdings_by_reb,
+            divisors_by_reb=divisors_by_reb,
+            pending_holdings_rows=pending_holdings_rows,
+            pending_divisor_rows=pending_divisor_rows,
         )
         if prev_trade and current_reb and current_reb in holdings_by_reb:
             prices_prev = db.fetch_prices(

--- a/tools/index_engine/verify_index_integrity.py
+++ b/tools/index_engine/verify_index_integrity.py
@@ -81,6 +81,9 @@ def _rebalance_checks(
     maximum_bridge = (0.0, None)
     maximum_anchor = (0.0, None)
     total_missing = 0
+    missing_price_details: list[str] = []
+    missing_state_count = 0
+    missing_state_details: list[str] = []
     total_stale = 0
     stale_quality = 0
     for rebalance_date in rebalance_dates:
@@ -130,8 +133,20 @@ def _rebalance_checks(
             },
         )
         prices = {str(ticker): float(price) for ticker, price in cur.fetchall() if price is not None}
-        if previous_level is None or previous_divisor is None or new_divisor is None:
-            total_missing += len(shares)
+        missing_state = [
+            name
+            for name, value in (
+                ("previous_level", previous_level),
+                ("previous_divisor", previous_divisor),
+                ("new_divisor", new_divisor),
+            )
+            if value is None
+        ]
+        if missing_state:
+            missing_state_count += len(missing_state)
+            missing_state_details.append(
+                f"{rebalance_date.isoformat()}:{','.join(missing_state)}"
+            )
             continue
         audit = audit_rebalance(
             previous_level=float(previous_level),
@@ -143,6 +158,10 @@ def _rebalance_checks(
             anchor_relative_tolerance=anchor_tolerance,
         )
         total_missing += audit.missing_price_count
+        missing_price_details.extend(
+            f"{rebalance_date.isoformat()}:{ticker}"
+            for ticker in sorted(set(shares) - set(prices))
+        )
         total_stale += audit.stale_anchor_count
         if abs(audit.bridge_residual) > abs(maximum_bridge[0]):
             maximum_bridge = (audit.bridge_residual, rebalance_date)
@@ -164,7 +183,20 @@ def _rebalance_checks(
             bridge_tolerance,
             date=maximum_bridge[1],
         ),
-        IntegrityCheck("rebalance_missing_exact_prices", total_missing, 0, total_missing == 0),
+        IntegrityCheck(
+            "rebalance_missing_exact_prices",
+            total_missing,
+            0,
+            total_missing == 0,
+            detail=";".join(missing_price_details[:25]),
+        ),
+        IntegrityCheck(
+            "rebalance_missing_state_prerequisites",
+            missing_state_count,
+            0,
+            missing_state_count == 0,
+            detail=";".join(missing_state_details[:25]),
+        ),
         IntegrityCheck(
             "rebalance_stale_anchor_count",
             total_stale,


### PR DESCRIPTION
## Summary

- Fix the strict-verification failure from production run `ca-da499bec-135a-4ea8-a472-d7b9888c83bb` (backup `202607130908444E9C`).
- Preserve the seeded 2025-01-02 TECH100 holdings/divisor snapshot across a full-range rebuild delete.
- Keep exact-anchor and partial-output gates fail-closed while distinguishing missing rebalance state from genuinely missing canonical prices.
- Production remained on the independently restored baseline; this change did not deploy or launch reconstruction.

## Changes

- Stage an in-range seeded rebalance snapshot for identical repersistence before `delete_holdings_divisor()` executes.
- Preserve the stored shares and divisor and the documented equal target weights; index and portfolio mathematics are unchanged.
- Add `rebalance_missing_state_prerequisites` and exact ticker/date detail so missing level/divisor state is not mislabeled as missing price data.
- Document the base-snapshot persistence rule and strict diagnostic distinction.

Root cause of the reported 25 missing exact prices:

- All 25 affected tickers had an exact canonical adjusted price on the required 2025-03-31 anchor date for the 2025-04-01 rebalance: `AAPL`, `ADBE`, `ADSK`, `AMD`, `AMZN`, `ARM`, `AZN`, `CSCO`, `CTSH`, `FISV`, `GEHC`, `GOOGL`, `HON`, `INTC`, `INTU`, `META`, `MSFT`, `NVDA`, `NXPI`, `PANW`, `PYPL`, `QCOM`, `TEAM`, `VRSK`, `WDAY`.
- The rebuild seeded 2025-01-02 holdings/divisor from Oracle, used them correctly for all calculations, deleted that persisted snapshot with the reconstruction range, and did not queue it for repersistence because the first calculation date was not treated as a universe transition.
- At 2025-04-01, strict verification therefore found no prior divisor and its old diagnostic path added all 25 holdings to `rebalance_missing_exact_prices`. The underlying defect was official holdings/divisor persistence plus verifier classification, not canonical-price generation, trading-calendar selection, corporate-action adjustment, or anchor fallback.

Root cause of the 60 partial dates:

- The same missing 2025-01-02 holdings snapshot left no applicable persisted basket for every one of the 60 TECH100 trading dates from 2025-01-02 through 2025-03-31.
- Exact dates: `2025-01-02`, `2025-01-03`, `2025-01-06`, `2025-01-07`, `2025-01-08`, `2025-01-10`, `2025-01-13`, `2025-01-14`, `2025-01-15`, `2025-01-16`, `2025-01-17`, `2025-01-21`, `2025-01-22`, `2025-01-23`, `2025-01-24`, `2025-01-27`, `2025-01-28`, `2025-01-29`, `2025-01-30`, `2025-01-31`, `2025-02-03`, `2025-02-04`, `2025-02-05`, `2025-02-06`, `2025-02-07`, `2025-02-10`, `2025-02-11`, `2025-02-12`, `2025-02-13`, `2025-02-14`, `2025-02-18`, `2025-02-19`, `2025-02-20`, `2025-02-21`, `2025-02-24`, `2025-02-25`, `2025-02-26`, `2025-02-27`, `2025-02-28`, `2025-03-03`, `2025-03-04`, `2025-03-05`, `2025-03-06`, `2025-03-07`, `2025-03-10`, `2025-03-11`, `2025-03-12`, `2025-03-13`, `2025-03-14`, `2025-03-17`, `2025-03-18`, `2025-03-19`, `2025-03-20`, `2025-03-21`, `2025-03-24`, `2025-03-25`, `2025-03-26`, `2025-03-27`, `2025-03-28`, `2025-03-31`.
- The reconstructed rows themselves were complete: 25 constituent rows on every date, zero contribution rows on the base date, and 25 contribution rows thereafter. The verifier calculated an expected count of zero because the base holdings row had been deleted. This was a persistence-plan defect, not model eligibility, inception, warm-up, final-batch, or transaction-boundary loss.
- All six models (`TECH100`, `TECH100_EQ`, `TECH100_GOV`, `TECH100_MOM`, `TECH100_LOWVOL`, `TECH100_GOV_MOM`) completed 380 dates and were not the source of this official-output gate.

## Testing

- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 /mnt/c/codex/Sustainacore/.venv/bin/python -m pytest -q tests/test_calc_index_rebalance_guards.py tests/test_index_integrity.py` — 22 passed.
- Broader SC_IDX suite covering reconstruction, readiness, official calculation, corporate actions, price ingestion, integrity, portfolio output, persistence, launcher, status, rollback, and pipeline orchestration — 202 passed.
- `python tools/guard_forbidden_terms.py` — passed.
- `python -m compileall -q app/index_engine tools/index_engine tools/db_migrations` — passed.
- `bash -n tools/index_engine/run_reconstruction_low_resource.sh` — passed.
- `git diff --check` — passed.

Regression coverage proves:

- a seeded base snapshot inside the delete window is staged and repersisted unchanged;
- a seed before the delete window is not rewritten;
- incomplete seeded state fails before publication;
- the complete 60-date first period has zero partial dates after repersistence;
- a missing prior divisor is a strict state-prerequisite failure, not 25 fictional missing prices;
- genuinely missing exact prices, stale anchors, corporate-action basis mismatch, and rebalance continuity still fail closed.

## Evidence

- Read-only Oracle inspection found the six restored baseline source gaps previously handled by readiness, but all 25 reported April identities had `EXACT` canonical adjusted prices on 2025-03-31.
- Current-main no-write reproduction: 380 levels, 9,500 constituent rows, 9,475 contribution rows, six newly staged rebalances, and 60 partial dates because the seeded base snapshot was omitted from persistence.
- Fixed-code no-write reproduction against the same source shape: 380 levels, 9,500 constituent rows, 9,475 contribution rows, seven staged rebalances, and `captured_partial_count=0`.
- Both reproductions replaced every official persistence, deletion, job-run, and corporate-action write with in-memory capture and reported `oracle_writes=0`.
- The prior production attempt automatically compensated and was independently restored. During this task: production Oracle writes `0`; production reconstruction launches `0`; deployments `0`.
- VM1 remained safe: `sc-idx-pipeline.timer=inactive`, `sc-idx-pipeline.service=inactive`.

## Notes / Follow-ups

- This Pull Request is intentionally draft. Do not merge or deploy until human review and Continuous Integration are complete.
- Post-merge plan: deploy the reviewed merge revision, repeat default dry-run and exhaustive readiness, confirm the restored baseline, then perform one controlled low-resource reconstruction with a new backup tag/run ID and all strict gates.
- Do not reuse backup tag `202607130908444E9C`; preserve it as recovery evidence.
